### PR TITLE
Projects name change

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 If your are using the latest image tag and recently updated your image: please make sure you've checked the required read on the project's README.
 
-HTTPS does not work / certificate aren't created : please check in your letsencrypt-nginx-proxy-companion container logs if an authorization or verify error is mentioned, if it is please do the following before opening an issue:
+HTTPS does not work / certificate aren't created : please check in your acme-companion container logs if an authorization or verify error is mentioned, if it is please do the following before opening an issue:
 - check and follow the troubleshooting instructions in the docs.
 - search the existing similar issues, both opened and closed.
 
@@ -18,12 +18,12 @@ Bug description
 
 A clear and concise description of what the bug is.
 
-letsencrypt-nginx-proxy-companion image version
+acme-companion image version
 -----------------
 
 Please provide the container version that should be printed to the first line of log at container startup:
 ```
-Info: running letsencrypt-nginx-proxy-companion version v2.0.0
+Info: running acme-companion version v2.0.0
 ```
 
 If this first log line isn't present you are using a v1 image: please provide the tagged version you are using. If you are not using a tagged version latest, please try again with a tagged release before opening an issue (the last v1 tagged release is v1.13.1).
@@ -39,7 +39,7 @@ Containers logs
 -----------------
 
 Please provide the logs of:
-- your letsencrypt-nginx-proxy-companion container
+- your acme-companion container
 - your nginx-proxy container (or nginx and docker-gen container in a three containers setup)
 
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ Info: running letsencrypt-nginx-proxy-companion version v2.0.0
 
 If this first log line isn't present you are using a v1 image: please provide the tagged version you are using. If you are not using a tagged version latest, please try again with a tagged release before opening an issue (the last v1 tagged release is v1.13.1).
 
-nginx-proxy-companion configuration
+nginx-proxy configuration
 -----------------
 
 Please provide the configuration (either command line, compose file, or other) of your nginx-proxy stack and your proxied container(s).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,14 +51,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Build patched nginx-proxy Image
-        run: docker build -t "jwilder/nginx-proxy:latest" ./test/setup/nginx-proxy
+        run: docker build -t "nginxproxy/nginx-proxy:latest" ./test/setup/nginx-proxy
       - name: Build patched docker-gen Image
         run: docker build -t "jwilder/docker-gen:latest" ./test/setup/docker-gen
       - name: List Docker Images
         run: docker images
       - name: Export Images Artifacts
         run: |
-          docker save jwilder/nginx-proxy:latest > nginx-proxy.tar
+          docker save nginxproxy/nginx-proxy:latest > nginx-proxy.tar
           docker save jwilder/docker-gen:latest > docker-gen.tar
       - name: Upload nginx-proxy Image Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   DOCKER_GEN_CONTAINER_NAME: nginx-proxy-gen
-  IMAGE: jrcs/letsencrypt-nginx-proxy-companion
+  IMAGE: nginxproxy/acme-companion
   NGINX_CONTAINER_NAME: nginx-proxy
   TEST_DOMAINS: le1.wtf,le2.wtf,le3.wtf
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ docker run --detach \
     --volume vhost:/etc/nginx/vhost.d \
     --volume html:/usr/share/nginx/html \
     --volume /var/run/docker.sock:/tmp/docker.sock:ro \
-    jwilder/nginx-proxy
+    nginxproxy/nginx-proxy
 ```
 
 Binding the host docker socket (`/var/run/docker.sock`) inside the container to `/tmp/docker.sock` is a requirement of **nginx-proxy**.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-![Tests](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/workflows/Tests/badge.svg)
-[![GitHub release](https://img.shields.io/github/release/nginx-proxy/docker-letsencrypt-nginx-proxy-companion.svg)](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/releases)
-[![Image info](https://images.microbadger.com/badges/image/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
-[![Docker stars](https://img.shields.io/docker/stars/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
-[![Docker pulls](https://img.shields.io/docker/pulls/jrcs/letsencrypt-nginx-proxy-companion.svg)](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion "Click to view the image on Docker Hub")
+![Tests](https://github.com/nginx-proxy/acme-companion/workflows/Tests/badge.svg)
+[![GitHub release](https://img.shields.io/github/release/nginx-proxy/acme-companion.svg)](https://github.com/nginx-proxy/acme-companion/releases)
+[![Image info](https://images.microbadger.com/badges/image/nginxproxy/acme-companion.svg)](https://hub.docker.com/r/nginxproxy/acme-companion "Click to view the image on Docker Hub")
+[![Docker stars](https://img.shields.io/docker/stars/nginxproxy/acme-companion.svg)](https://hub.docker.com/r/nginxproxy/acme-companion "Click to view the image on Docker Hub")
+[![Docker pulls](https://img.shields.io/docker/pulls/nginxproxy/acme-companion.svg)](https://hub.docker.com/r/nginxproxy/acme-companion "Click to view the image on Docker Hub")
 
-**letsencrypt-nginx-proxy-companion** is a lightweight companion container for [**nginx-proxy**](https://github.com/nginx-proxy/nginx-proxy).
+**acme-companion** is a lightweight companion container for [**nginx-proxy**](https://github.com/nginx-proxy/nginx-proxy).
 
-It handles the automated creation, renewal and use of Let's Encrypt certificates for proxied Docker containers.
+It handles the automated creation, renewal and use of SSL certificates for proxied Docker containers through the ACME protocol.
 
-**Required read if you use the `latest` version** : the recent `v2.0.0` release of this project mark the switch of the ACME client used by the Docker image from [**simp.le**](https://github.com/zenhack/simp_le) to [**acme.sh**](https://github.com/acmesh-official/acme.sh). This switch result in some backward incompatible changes, so please read [this issue](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/issues/510) and the updated docs for more details before updating your image. The single most important change is that the container now requires a volume mounted to `/etc/acme.sh` in order to persist ACME account keys and SSL certificates. The last tagged version that uses **simp_le** is `v1.13.1`.
+**Required read if you use the `latest` version** : the `v2.0.0` release of this project mark the switch of the ACME client used by the Docker image from [**simp.le**](https://github.com/zenhack/simp_le) to [**acme.sh**](https://github.com/acmesh-official/acme.sh). This switch result in some backward incompatible changes, so please read [this issue](https://github.com/nginx-proxy/acme-companion/issues/510) and the updated docs for more details before updating your image. The single most important change is that the container now requires a volume mounted to `/etc/acme.sh` in order to persist ACME account keys and SSL certificates. The last tagged version that uses **simp_le** is `v1.13.1`.
 
 ### Features:
 * Automated creation/renewal of Let's Encrypt (or other ACME CAs) certificates using [**acme.sh**](https://github.com/acmesh-official/acme.sh).
 * Let's Encrypt / ACME domain validation through `http-01` challenge only.
 * Automated update and reload of nginx config on certificate creation/renewal.
-* Support creation of [Multi-Domain (SAN) Certificates](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/blob/master/docs/Let's-Encrypt-and-ACME.md#multi-domains-certificates).
+* Support creation of [Multi-Domain (SAN) Certificates](https://github.com/nginx-proxy/acme-companion/blob/master/docs/Let's-Encrypt-and-ACME.md#multi-domains-certificates).
 * Creation of a Strong Diffie-Hellman Group at startup.
 * Work with all versions of docker.
 
@@ -26,17 +26,17 @@ It handles the automated creation, renewal and use of Let's Encrypt certificates
 * Your DNS provider must [answer correctly to CAA record requests](https://letsencrypt.org/docs/caa/).
 * If your (sub)domains have AAAA records set, the host must be publicly reachable over IPv6 on port `80` and `443`.
 
-![schema](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/blob/master/schema.png)
+![schema](https://github.com/nginx-proxy/acme-companion/blob/master/schema.png)
 
 ## Basic usage (with the nginx-proxy container)
 
-Three writable volumes must be declared on the **nginx-proxy** container so that they can be shared with the **letsencrypt-nginx-proxy-companion** container:
+Three writable volumes must be declared on the **nginx-proxy** container so that they can be shared with the **acme-companion** container:
 
 * `/etc/nginx/certs` to store certificates and private keys (readonly for the **nginx-proxy** container).
 * `/etc/nginx/vhost.d` to change the configuration of vhosts (required so the CA may access `http-01` challenge files).
 * `/usr/share/nginx/html` to write `http-01` challenge files.
 
-Additionally, a fourth volume must be declared on the **letsencrypt-nginx-proxy-companion** container to store `acme.sh` configuration and state: `/etc/acme.sh`.
+Additionally, a fourth volume must be declared on the **acme-companion** container to store `acme.sh` configuration and state: `/etc/acme.sh`.
 
 Please also read the doc about [data persistence](./docs/Persistent-data.md).
 
@@ -60,18 +60,18 @@ $ docker run --detach \
 
 Binding the host docker socket (`/var/run/docker.sock`) inside the container to `/tmp/docker.sock` is a requirement of **nginx-proxy**.
 
-### Step 2 - letsencrypt-nginx-proxy-companion
+### Step 2 - acme-companion
 
-Start the **letsencrypt-nginx-proxy-companion** container, getting the volumes from **nginx-proxy** with `--volumes-from`:
+Start the **acme-companion** container, getting the volumes from **nginx-proxy** with `--volumes-from`:
 
 ```shell
 $ docker run --detach \
-    --name nginx-proxy-letsencrypt \
+    --name nginx-proxy-acme \
     --volumes-from nginx-proxy \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
     --volume acme:/etc/acme.sh \
     --env "DEFAULT_EMAIL=mail@yourdomain.tld" \
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```
 
 The host docker socket has to be bound inside this container too, this time to `/var/run/docker.sock`.
@@ -80,9 +80,9 @@ Albeit **optional**, it is **recommended** to provide a valid default email addr
 
 ### Step 3 - proxied container(s)
 
-Once both **nginx-proxy** and **letsencrypt-nginx-proxy-companion** containers are up and running, start any container you want proxied with environment variables `VIRTUAL_HOST` and `LETSENCRYPT_HOST` both set to the domain(s) your proxied container is going to use.
+Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxied with environment variables `VIRTUAL_HOST` and `LETSENCRYPT_HOST` both set to the domain(s) your proxied container is going to use.
 
-[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `LETSENCRYPT_HOST` control certificate creation and SSL enabling by **letsencrypt-nginx-proxy-companion**.
+[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `LETSENCRYPT_HOST` control certificate creation and SSL enabling by **acme-companion**.
 
 Certificates will only be issued for containers that have both `VIRTUAL_HOST` and `LETSENCRYPT_HOST` variables set to domain(s) that correctly resolve to the host, provided the host is publicly reachable.
 
@@ -114,4 +114,4 @@ Repeat [Step 3](#step-3---proxied-containers) for any other container you want t
 
 ## Additional documentation
 
-Please check the [docs section](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/tree/master/docs).
+Please check the [docs section](https://github.com/nginx-proxy/acme-companion/tree/master/docs).

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -7,7 +7,7 @@ source /app/functions.sh
 
 function print_version {
     if [[ -n "${COMPANION_VERSION:-}" ]]; then
-        echo "Info: running letsencrypt-nginx-proxy-companion version ${COMPANION_VERSION}"
+        echo "Info: running acme-companion version ${COMPANION_VERSION}"
     fi
 }
 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -101,10 +101,10 @@ function cleanup_links {
           cert_folder="$(readlink -f "/etc/nginx/certs/${disabled_domain}.crt")"
           # If the dotfile is absent, skip domain.
           if [[ ! -e "${cert_folder%/*}/.companion" ]]; then
-              [[ "$DEBUG" == 1 ]] && echo "No .companion file found in ${cert_folder}. ${disabled_domain} is not managed by letsencrypt-nginx-proxy-companion. Skipping domain."
+              [[ "$DEBUG" == 1 ]] && echo "No .companion file found in ${cert_folder}. ${disabled_domain} is not managed by acme-companion. Skipping domain."
               continue
           else
-              [[ "$DEBUG" == 1 ]] && echo "${disabled_domain} is managed by letsencrypt-nginx-proxy-companion. Removing unused symlinks."
+              [[ "$DEBUG" == 1 ]] && echo "${disabled_domain} is managed by acme-companion. Removing unused symlinks."
           fi
 
           for extension in .crt .key .dhparam.pem .chain.pem; do

--- a/docs/Advanced-usage.md
+++ b/docs/Advanced-usage.md
@@ -4,7 +4,7 @@
 
 **NOTE**: The first time this container is launched in a three container setup, it will generates a new 2048 bits Diffie-Hellman parameters file. This process can take up to several minutes to complete on lower end hosts, and certificates creation won't start before that (be patient).
 
-Please read and try [basic usage](./Basic-usage.md), and **validate that you have a working two containers setup** before using the three containers setup. In addition to the steps described there, running **nginx-proxy** as two separate containers with **letsencrypt-nginx-proxy-companion** requires the following:
+Please read and try [basic usage](./Basic-usage.md), and **validate that you have a working two containers setup** before using the three containers setup. In addition to the steps described there, running **nginx-proxy** as two separate containers with **acme-companion** requires the following:
 
 1) Download and mount the template file [nginx.tmpl](https://github.com/nginx-proxy/nginx-proxy/blob/master/nginx.tmpl) into the **docker-gen** container. You can get the nginx.tmpl file with a command like:
 
@@ -12,7 +12,7 @@ Please read and try [basic usage](./Basic-usage.md), and **validate that you hav
 curl https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl > /path/to/nginx.tmpl
 ```
 
-2) Use the `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` label on the **docker-gen** container, or explicitly set the `NGINX_DOCKER_GEN_CONTAINER` environment variable on the **letsencrypt-nginx-proxy-companion** container to the name or id of the **docker-gen** container (we'll use the later method in the example).
+2) Use the `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` label on the **docker-gen** container, or explicitly set the `NGINX_DOCKER_GEN_CONTAINER` environment variable on the **acme-companion** container to the name or id of the **docker-gen** container (we'll use the later method in the example).
 
 3) Declare `/etc/nginx/conf.d` as a volume on the nginx container so that it can be shared with the **docker-gen** container.
 
@@ -52,19 +52,19 @@ $ docker run --detach \
 Note that you must pass the exact name of the **nginx** container to **docker-gen** `-notify-sighup` argument (here `nginx-proxy`).
 
 
-### Step 3 - letsencrypt-nginx-proxy-companion
+### Step 3 - acme-companion
 
-* Start the **letsencrypt-nginx-proxy-companion** container with the `NGINX_DOCKER_GEN_CONTAINER` environment variable correctly set:
+* Start the **acme-companion** container with the `NGINX_DOCKER_GEN_CONTAINER` environment variable correctly set:
 
 ```shell
 $ docker run --detach \
-    --name nginx-proxy-letsencrypt \
+    --name nginx-proxy-acme \
     --volumes-from nginx-proxy \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
     --volume acme:/etc/acme.sh \
     --env "NGINX_DOCKER_GEN_CONTAINER=nginx-proxy-gen" \
     --env "DEFAULT_EMAIL=mail@yourdomain.tld" \
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```
 
 ### Step 4 - proxyed container(s)

--- a/docs/Basic-usage.md
+++ b/docs/Basic-usage.md
@@ -25,7 +25,7 @@ $ docker run --detach \
     --volume vhost:/etc/nginx/vhost.d \
     --volume html:/usr/share/nginx/html \
     --volume /var/run/docker.sock:/tmp/docker.sock:ro \
-    jwilder/nginx-proxy
+    nginxproxy/nginx-proxy
 ```
 
 Binding the host docker socket (`/var/run/docker.sock`) inside the container to `/tmp/docker.sock` is a requirement of **nginx-proxy**.

--- a/docs/Basic-usage.md
+++ b/docs/Basic-usage.md
@@ -1,12 +1,12 @@
 ## Basic usage (with the nginx-proxy container)
 
-Three writable volumes must be declared on the **nginx-proxy** container so that they can be shared with the **letsencrypt-nginx-proxy-companion** container:
+Three writable volumes must be declared on the **nginx-proxy** container so that they can be shared with the **acme-companion** container:
 
 * `/etc/nginx/certs` to store certificates and private keys (readonly for the **nginx-proxy** container).
 * `/etc/nginx/vhost.d` to change the configuration of vhosts (required so the CA may access `http-01` challenge files).
 * `/usr/share/nginx/html` to write `http-01` challenge files.
 
-Additionally, a fourth volume must be declared on the **letsencrypt-nginx-proxy-companion** container to store `acme.sh` configuration and state: `/etc/acme.sh`.
+Additionally, a fourth volume must be declared on the **acme-companion** container to store `acme.sh` configuration and state: `/etc/acme.sh`.
 
 Please also read the doc about [data persistence](./Persistent-data.md).
 
@@ -30,18 +30,18 @@ $ docker run --detach \
 
 Binding the host docker socket (`/var/run/docker.sock`) inside the container to `/tmp/docker.sock` is a requirement of **nginx-proxy**.
 
-### Step 2 - letsencrypt-nginx-proxy-companion
+### Step 2 - acme-companion
 
-Start the **letsencrypt-nginx-proxy-companion** container, getting the volumes from **nginx-proxy** with `--volumes-from`:
+Start the **acme-companion** container, getting the volumes from **nginx-proxy** with `--volumes-from`:
 
 ```shell
 $ docker run --detach \
-    --name nginx-proxy-letsencrypt \
+    --name nginx-proxy-acme \
     --volumes-from nginx-proxy \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
     --volume acme:/etc/acme.sh \
     --env "DEFAULT_EMAIL=mail@yourdomain.tld" \
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```
 
 The host docker socket has to be bound inside this container too, this time to `/var/run/docker.sock`.
@@ -50,9 +50,9 @@ Albeit **optional**, it is **recommended** to provide a valid default email addr
 
 ### Step 3 - proxyed container(s)
 
-Once both **nginx-proxy** and **letsencrypt-nginx-proxy-companion** containers are up and running, start any container you want proxyed with environment variables `VIRTUAL_HOST` and `LETSENCRYPT_HOST` both set to the domain(s) your proxyed container is going to use. Multiple hosts can be separated using commas.
+Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxyed with environment variables `VIRTUAL_HOST` and `LETSENCRYPT_HOST` both set to the domain(s) your proxyed container is going to use. Multiple hosts can be separated using commas.
 
-[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `LETSENCRYPT_HOST` control certificate creation and SSL enabling by **letsencrypt-nginx-proxy-companion**.
+[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `LETSENCRYPT_HOST` control certificate creation and SSL enabling by **acme-companion**.
 
 Certificates will only be issued for containers that have both `VIRTUAL_HOST` and `LETSENCRYPT_HOST` variables set to domain(s) that correctly resolve to the host, provided the host is publicly reachable.
 

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -8,13 +8,13 @@ For example
 
 ```bash
 $ docker run --detach \
-    --name nginx-proxy-letsencrypt \
+    --name nginx-proxy-acme \
     --volumes-from nginx-proxy \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
     --volume certs:/etc/nginx/certs:rw \
     --volume acme:/etc/acme.sh \
     --env "ACME_CA_URI=https://acme-staging-v02.api.letsencrypt.org/directory" \
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```
 You can also create test certificates per container (see [Test certificates](./Let's-Encrypt-and-ACME.md#test-certificates))
 

--- a/docs/Container-utilities.md
+++ b/docs/Container-utilities.md
@@ -1,17 +1,17 @@
-The container provide the following utilities (replace `nginx-letsencrypt` with the name or ID of your **letsencrypt-nginx-proxy-companion** container when executing the commands):
+The container provide the following utilities (replace `nginx-proxy-acme` with the name or ID of your **acme-companion** container when executing the commands):
 
 ### Force certificates renewal
-If needed, you can force a running **letsencrypt-nginx-proxy-companion** container to renew all certificates that are currently in use with the following command:
+If needed, you can force a running **acme-companion** container to renew all certificates that are currently in use with the following command:
 
 ```bash
-$ docker exec nginx-letsencrypt /app/force_renew
+$ docker exec nginx-proxy-acme /app/force_renew
 ```
 
 ### Manually trigger the service loop
 You can trigger the execution of the service loop before the hourly execution with:
 
 ```bash
-$ docker exec nginx-letsencrypt /app/signal_le_service
+$ docker exec nginx-proxy-acme /app/signal_le_service
 ```
 Unlike the previous command, this won't force renewal of certificates that don't need to be renewed.
 
@@ -19,5 +19,5 @@ Unlike the previous command, this won't force renewal of certificates that don't
 To display informations about your existing certificates, use the following command:
 
 ```bash
-$ docker exec nginx-letsencrypt /app/cert_status
+$ docker exec nginx-proxy-acme /app/cert_status
 ```

--- a/docs/Docker-Compose.md
+++ b/docs/Docker-Compose.md
@@ -19,7 +19,7 @@ version: '2'
 
 services:
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: nginxproxy/nginx-proxy
     container_name: nginx-proxy
     ports:
       - "80:80"

--- a/docs/Docker-Compose.md
+++ b/docs/Docker-Compose.md
@@ -1,6 +1,6 @@
 ## Usage with Docker Compose
 
-As stated by its repository, [Docker Compose](https://github.com/docker/compose) is a tool for defining and running multi-container Docker applications using a single _Compose file_. This Wiki page is not meant to be a definitive reference on how to run **nginx-proxy** and **letsencrypt-nginx-proxy-companion** with Docker Compose, as the number of possible setups is quite extensive and they can't be all covered.
+As stated by its repository, [Docker Compose](https://github.com/docker/compose) is a tool for defining and running multi-container Docker applications using a single _Compose file_. This Wiki page is not meant to be a definitive reference on how to run **nginx-proxy** and **acme-companion** with Docker Compose, as the number of possible setups is quite extensive and they can't be all covered.
 
 ### Before your start
 
@@ -33,9 +33,9 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     network_mode: bridge
 
-  letsencrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
-    container_name: nginx-proxy-le
+  acme-companion:
+    image: nginxproxy/acme-companion
+    container_name: nginx-proxy-acme
     volumes_from:
       - nginx-proxy
     volumes:
@@ -87,9 +87,9 @@ services:
       - "com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen"
     network_mode: bridge
 
-  letsencrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
-    container_name: nginx-proxy-le
+  acme-companion:
+    image: nginxproxy/acme-companion
+    container_name: nginx-proxy-acme
     volumes_from:
       - nginx-proxy
     volumes:

--- a/docs/Getting-containers-IDs.md
+++ b/docs/Getting-containers-IDs.md
@@ -1,24 +1,24 @@
 ## Getting nginx-proxy/nginx/docker-gen containers IDs
 
-For **letsencrypt-nginx-proxy-companion** to work properly, it needs to know the ID of the **nginx**/**nginx-proxy** container (in both [two](./Basic-usage.md) and [three](./Advanced-usage.md) containers setups), plus the ID of the **docker-gen** container in a [three container setup](./Advanced-usage.md).
+For **acme-companion** to work properly, it needs to know the ID of the **nginx**/**nginx-proxy** container (in both [two](./Basic-usage.md) and [three](./Advanced-usage.md) containers setups), plus the ID of the **docker-gen** container in a [three container setup](./Advanced-usage.md).
 
-There are three methods to inform the **letsencrypt-nginx-proxy-companion** container of the **nginx**/**nginx-proxy** container ID:
+There are three methods to inform the **acme-companion** container of the **nginx**/**nginx-proxy** container ID:
 
 * `label` method: add the label `com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy` to the **nginx**/**nginx-proxy** container.
 
-* `environment variable` method: assign a fixed name to the **nginx**/**nginx-proxy** container with `container_name:` and set the environment variable `NGINX_PROXY_CONTAINER` to this name on the **letsencrypt-nginx-proxy-companion** container.
+* `environment variable` method: assign a fixed name to the **nginx**/**nginx-proxy** container with `container_name:` and set the environment variable `NGINX_PROXY_CONTAINER` to this name on the **acme-companion** container.
 
-* `volumes_from` method. Using this method, the **letsencrypt-nginx-proxy-companion** container will get the **nginx**/**nginx-proxy** container ID from the volumes it got using the `volumes_from` option.
+* `volumes_from` method. Using this method, the **acme-companion** container will get the **nginx**/**nginx-proxy** container ID from the volumes it got using the `volumes_from` option.
 
-And two methods to inform the **letsencrypt-nginx-proxy-companion** container of the **docker-gen** container ID:
+And two methods to inform the **acme-companion** container of the **docker-gen** container ID:
 
 * `label` method: add the label `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` to the **docker-gen** container.
 
-* `environment variable` method: assign a fixed name to the **docker-gen** container with `container_name:` and set the environment variable `NGINX_DOCKER_GEN_CONTAINER` to this name on the **letsencrypt-nginx-proxy-companion** container.
+* `environment variable` method: assign a fixed name to the **docker-gen** container with `container_name:` and set the environment variable `NGINX_DOCKER_GEN_CONTAINER` to this name on the **acme-companion** container.
 
 The methods for each container are sorted by order of precedence, meaning that if you use both the label and the volumes_from method, the ID of the **nginx**/**nginx-proxy** container that will be used will be the one found using the label. **There is no point in using more than one method at a time for either the nginx/nginx-proxy or docker-gen container beside potentially confusing yourself**.
 
-The advantage the `label` methods have over the `environment variable` (and `volumes_from`) methods is enabling the use of the **letsencrypt-nginx-proxy-companion** in environments where containers names are dynamic, like in Swarm Mode or in Docker Cloud. Howhever if you intend to do so, as upstream **docker-gen** lacks the ability to identify containers from labels, you'll need both to either use the two containers setup or to replace jwilder/docker-gen with a fork that has this ability like [herlderco/docker-gen](https://github.com/helderco/docker-gen). Be advised that for now, this works to a very limited extent [(everything has to be on the same node)](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/pull/231#issuecomment-330624331).
+The advantage the `label` methods have over the `environment variable` (and `volumes_from`) methods is enabling the use of the **acme-companion** in environments where containers names are dynamic, like in Swarm Mode or in Docker Cloud. Howhever if you intend to do so, as upstream **docker-gen** lacks the ability to identify containers from labels, you'll need both to either use the two containers setup or to replace jwilder/docker-gen with a fork that has this ability like [herlderco/docker-gen](https://github.com/helderco/docker-gen). Be advised that for now, this works to a very limited extent [(everything has to be on the same node)](https://github.com/nginx-proxy/acme-companion/pull/231#issuecomment-330624331).
 
 #### Examples with three containers setups:
 
@@ -36,7 +36,7 @@ $ docker run --detach \
 
 $ docker run --detach \
     [...]
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```
 
 `environment variable` method
@@ -55,7 +55,7 @@ $ docker run --detach \
     [...]
     --env NGINX_PROXY_CONTAINER=unique-container-name \
     --env NGINX_DOCKER_GEN_CONTAINER=another-unique-container-name \
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```
 
 `volumes_from` (**nginx**) + `label` (**docker-gen**) method
@@ -73,7 +73,7 @@ $ docker run --detach \
 $ docker run --detach \
     [...]
     --volumes-from unique-container-name \
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```
 
 `volumes_from` (**nginx**) + `environment variable` (**docker-gen**) method
@@ -92,5 +92,5 @@ $ docker run --detach \
     [...]
     --volumes-from unique-container-name \
     --env NGINX_DOCKER_GEN_CONTAINER=another-unique-container-name \
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```

--- a/docs/Invalid-authorizations.md
+++ b/docs/Invalid-authorizations.md
@@ -1,6 +1,6 @@
 ## Troubleshooting failing authorizations
 
-The first two things to do in case of failing authorization are to run the **letsencrypt-nginx-proxy-companion** container with the environment variable `DEBUG=1` to enable the more detailed error messages, and to [request test certificates](./Let's-Encrypt-and-ACME.md#test-certificates) while troubleshooting the issue.
+The first two things to do in case of failing authorization are to run the **acme-companion** container with the environment variable `DEBUG=1` to enable the more detailed error messages, and to [request test certificates](./Let's-Encrypt-and-ACME.md#test-certificates) while troubleshooting the issue.
 
 Common causes of of failing authorizations:
 
@@ -42,7 +42,7 @@ If you are unsure of your host/hosts's docker IPv6 connectivity, drop the AAAA r
 
 Read https://letsencrypt.org/docs/caa/ and test with https://unboundtest.com/
 
-#### the **nginx-proxy**/**nginx**/**docker-gen**/**letsencrypt-nginx-proxy-companion** containers were misconfigured.
+#### the **nginx-proxy**/**nginx**/**docker-gen**/**acme-companion** containers were misconfigured.
 
 Review [basic usage](./Basic-usage.md) or [advanced usage](./Advanced-usage.md), plus the [nginx-proxy documentation](https://github.com/nginx-proxy/nginx-proxy).
 
@@ -52,9 +52,9 @@ Pay special attention to the fact that the volumes **MUST** be shared between th
 
 Both are required. Every domain on `LETSENCRYPT_HOST`**must** be on `VIRTUAL_HOST`too.
 
-#### you are using an outdated version of either **letsencrypt-nginx-proxy-companion** or the nginx.tmpl file (if running a 3 containers setup)
+#### you are using an outdated version of either **acme-companion** or the nginx.tmpl file (if running a 3 containers setup)
 
-Pull `jrcs/letsencrypt-nginx-proxy-companion:latest` again and get the latest [latest nginx.tmpl](https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl).
+Pull `nginxproxy/acme-companion:latest` again and get the latest [latest nginx.tmpl](https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl).
 
 
 ***

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -60,7 +60,7 @@ The `ACME_OCSP` environment variable, when set to `true` on a proxied applicatio
 
 The `LETSENCRYPT_TEST` environment variable, when set to `true` on a proxied application container, will create a test certificates that don't have the [5 certs/week/domain limits](https://letsencrypt.org/docs/rate-limits/) and are signed by an untrusted intermediate (they won't be trusted by browsers).
 
-If you want to do this globally for all containers, set `ACME_CA_URI` on the **letsencrypt-nginx-proxy-companion** container as described in [Container configuration](./Container-configuration.md).
+If you want to do this globally for all containers, set `ACME_CA_URI` on the **acme-companion** container as described in [Container configuration](./Container-configuration.md).
 
 #### ACME CA URI
 
@@ -74,15 +74,15 @@ If the ACME CA provides multiple cert chain, you can use the `ACME_PREFERRED_CHA
 
 The `LETSENCRYPT_RESTART_CONTAINER` environment variable, when set to `true` on an application container, will restart this container whenever the corresponding cert (`LETSENCRYPT_HOST`) is renewed. This is useful when certificates are directly used inside a container for other purposes than HTTPS (e.g. an FTPS server), to make sure those containers always use an up to date certificate.
 
-### global (set on letsencrypt-nginx-proxy-companion container)
+### global (set on acme-companion container)
 
 #### Default contact address
 
-The `DEFAULT_EMAIL` variable must be a valid email and, when set on the **letsencrypt_nginx_proxy_companion** container, will be used as a fallback when no email address is provided using proxyed container's `LETSENCRYPT_EMAIL` environment variables. It is highly recommended to set this variable to a valid email address that you own.
+The `DEFAULT_EMAIL` variable must be a valid email and, when set on the **acme-companion** container, will be used as a fallback when no email address is provided using proxyed container's `LETSENCRYPT_EMAIL` environment variables. It is highly recommended to set this variable to a valid email address that you own.
 
 #### Private key re-utilization
 
-The `RENEW_PRIVATE_KEYS` environment variable, when set to `false` on the **letsencrypt-nginx-proxy-companion** container, will set `acme.sh` to reuse previously generated private key instead of generating a new one at renewal for all domains.
+The `RENEW_PRIVATE_KEYS` environment variable, when set to `false` on the **acme-companion** container, will set `acme.sh` to reuse previously generated private key instead of generating a new one at renewal for all domains.
 
 Reusing private keys can help if you intend to use [HPKP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning), but please note that HPKP has been deprecated by Google's Chrome and that it is therefore strongly discouraged to use it at all.
 

--- a/docs/Persistent-data.md
+++ b/docs/Persistent-data.md
@@ -13,7 +13,7 @@ $ docker run -d \
     -v vhost:/etc/nginx/vhost.d \
     -v html:/usr/share/nginx/html \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
-    jwilder/nginx-proxy
+    nginxproxy/nginx-proxy
 
 $ docker volume ls
 DRIVER              VOLUME NAME
@@ -35,7 +35,7 @@ $ docker run -d \
     -v /etc/nginx/vhost.d \
     -v /usr/share/nginx/html \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
-    jwilder/nginx-proxy
+    nginxproxy/nginx-proxy
 
 $ docker volume ls
 DRIVER              VOLUME NAME

--- a/docs/Persistent-data.md
+++ b/docs/Persistent-data.md
@@ -60,11 +60,11 @@ Example with named volumes:
 
 `-v certs:/etc/nginx/certs:ro` on the **nginx-proxy** or **nginx** + **docker-gen** container(s).
 
-`-v certs:/etc/nginx/certs:rw` on the **letsencrypt-nginx-proxy-companion** container.
+`-v certs:/etc/nginx/certs:rw` on the **acme-companion** container.
 
 ## Ownership & permissions of private and ACME account keys
 
-By default, the **letsencrypt-nginx-proxy-companion** container will enforce the following ownership and permissions scheme on the files it creates and manage:
+By default, the **acme-companion** container will enforce the following ownership and permissions scheme on the files it creates and manage:
 
 ```
 [drwxr-xr-x]  /etc/nginx/certs
@@ -87,7 +87,7 @@ By default, the **letsencrypt-nginx-proxy-companion** container will enforce the
 └── [lrwxrwxrwx root root]  domain.tld.key -> ./domain.tld/key.pem
 ```
 
-This behavior can be customized using the following environment variable on the **letsencrypt-nginx-proxy-companion** container:
+This behavior can be customized using the following environment variable on the **acme-companion** container:
 
 * `FILES_UID` - Set the user owning the files and folders managed by the container. The variable can be either a user name if this user exists inside the container or a user numeric ID. Default to `root` (user ID `0`).
 * `FILES_GID` - Set the group owning the files and folders managed by the container. The variable can be either a group name if this group exists inside the container or a group numeric ID. Default to the same value as `FILES_UID`.
@@ -117,4 +117,4 @@ For example, `FILES_UID=1000`, `FILES_PERMS=600` and `FOLDERS_PERMS=700` will re
 └── [lrwxrwxrwx 1000 1000]  domain.tld.key -> ./domain.tld/key.pem
 ```
 
-If you just want to make the most sensitive files (private keys and ACME account keys) root readable only, set the environment variable `FILES_PERMS` to `600` on your **letsencrypt-nginx-proxy-companion** container.
+If you just want to make the most sensitive files (private keys and ACME account keys) root readable only, set the environment variable `FILES_PERMS` to `600` on your **acme-companion** container.

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -12,7 +12,7 @@ $ docker run --detach \
     --volume conf:/etc/nginx/conf.d \
     --volume html:/usr/share/nginx/html \
     --volume /var/run/docker.sock:/tmp/docker.sock:ro \
-    jwilder/nginx-proxy
+    nginxproxy/nginx-proxy
 ```
 ```bash
 $ docker run --detach \

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -1,6 +1,6 @@
 ## Standalone certificates
 
-You can generate certificate that are not tied to containers environment variable by mounting a user configuration file inside the container at `/app/letsencrypt_user_data`. This feature also require sharing the `/etc/nginx/conf.d` folder between the **nginx-proxy** and **letsencrypt-nginx-proxy-companion** container (and the **docker-gen** container if you are running a [three container setup](./Advanced-usage.md)):
+You can generate certificate that are not tied to containers environment variable by mounting a user configuration file inside the container at `/app/letsencrypt_user_data`. This feature also require sharing the `/etc/nginx/conf.d` folder between the **nginx-proxy** and **acme-companion** container (and the **docker-gen** container if you are running a [three container setup](./Advanced-usage.md)):
 
 ```bash
 $ docker run --detach \
@@ -16,12 +16,12 @@ $ docker run --detach \
 ```
 ```bash
 $ docker run --detach \
-    --name nginx-proxy-letsencrypt \
+    --name nginx-proxy-acme \
     --volumes-from nginx-proxy \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
     --volume acme:/etc/acme.sh \
     --volume /path/to/your/config_file:/app/letsencrypt_user_data:ro \
-    jrcs/letsencrypt-nginx-proxy-companion
+    nginxproxy/acme-companion
 ```
 
 The user configuration file is a collection of bash variables and array, and follows the syntax of the `/app/letsencrypt_service_data` file that get created by **docker-gen**.
@@ -70,4 +70,4 @@ Changes will either be picked up every hour when the service loop execute again,
 
 Please see the [**nginx-proxy** documentation](https://github.com/nginx-proxy/nginx-proxy#proxy-wide).
 
-No support will be provided on the **letsencrypt-nginx-proxy-companion** repo for proxying related issues or questions.
+No support will be provided on the **acme-companion** repo for proxying related issues or questions.

--- a/docs/Zero-SSL.md
+++ b/docs/Zero-SSL.md
@@ -17,6 +17,6 @@ Unlike Let's Encrypt, Zero SSL requires the use of an email bound account. If yo
 - provide pre-generated [EAB credentials](https://tools.ietf.org/html/rfc8555#section-7.3.4) using the `ACME_EAB_KID` and `ACME_EAB_HMAC_KEY` environment variables.
 - provide your ZeroSSL API key using the `ZEROSSL_API_KEY` environment variable.
 
-These variables can be set on the proxied containers or directly on the **letsencrypt-nginx-proxy-companion** container.
+These variables can be set on the proxied containers or directly on the **acme-companion** container.
 
-If you don't have a ZeroSSL account, you can let **letsencrypt-nginx-proxy-companion** create a Zero SSL account with the adress provided in the `ACME_EMAIL` or `DEFAULT_EMAIL` environment variable. Note that the adresse that will be used must be a valid email adress that you actually own.
+If you don't have a ZeroSSL account, you can let **acme-companion** create a Zero SSL account with the adress provided in the `ACME_EMAIL` or `DEFAULT_EMAIL` environment variable. Note that the adresse that will be used must be a valid email adress that you actually own.

--- a/test/README.md
+++ b/test/README.md
@@ -1,32 +1,32 @@
-### letsencrypt-nginx-proxy-companion test suite
+### acme-companion test suite
 
 The test suite can be run locally on a Linux or macOS host.
 
 To prepare the test setup:
 
 ```bash
-git clone https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion.git
-cd docker-letsencrypt-nginx-proxy-companion
+git clone https://github.com/nginx-proxy/acme-companion.git
+cd acme-companion
 test/setup/setup-local.sh --setup
 ```
 
 Then build the docker image and run the tests:
 
 ```bash
-docker build -t jrcs/letsencrypt-nginx-proxy-companion .
-test/run.sh jrcs/letsencrypt-nginx-proxy-companion
+docker build -t nginxproxy/acme-companion .
+test/run.sh nginxproxy/acme-companion
 ```
 
 You can limit the test run to specific test(s) with the `-t` flag:
 
 ```bash
-test/run.sh -t docker_api jrcs/letsencrypt-nginx-proxy-companion
+test/run.sh -t docker_api nginxproxy/acme-companion
 ```
 
 When running the test suite, the standard output of each individual test is captured and compared to its expected-std-out.txt file. When developing or modifying a test, you can use the `-d` flag to disable the standard output capture by the test suite.
 
 ```bash
-test/run.sh -d jrcs/letsencrypt-nginx-proxy-companion
+test/run.sh -d nginxproxy/acme-companion
 ```
 
 To remove the test setup:

--- a/test/run.sh
+++ b/test/run.sh
@@ -198,7 +198,7 @@
 
 set -e
 
-## Next twelve lines were added by jrcs/docker-letsencrypt-nginx-proxy-companion
+## Next twelve lines were added by nginxproxy/acme-companion
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 self="$(basename "$0")"
 failed_tests=()
@@ -226,7 +226,7 @@ EOUSAGE
 }
 
 # arg handling
-## Next nine lines were added or modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+## Next nine lines were added or modified by nginxproxy/acme-companion
 case "$(uname)" in
 	Linux)
 	opts="$(getopt -o 'hdkt:c:?' --long 'dry-run,help,test:,config:,keep-namespace' -- "$@" || { usage >&2 && false; })"
@@ -247,12 +247,12 @@ while true; do
 	flag=$1
 	shift
 	case "$flag" in
-		## Next line was modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+		## Next line was modified by nginxproxy/acme-companion
 		--dry-run|-d) dryRun=1 && export DRY_RUN=1 ;;
 		--help|-h|'-?') usage && exit 0 ;;
 		--test|-t) argTests["$1"]=1 && shift ;;
 		--config|-c) configs+=("$(readlink -f "$1")") && shift ;;
-		## Next line was modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+		## Next line was modified by nginxproxy/acme-companion
 		--keep-namespace|-k) keepNamespace=1 ;;
 		--) break ;;
 		*)
@@ -285,7 +285,7 @@ fi
 # load the configs
 declare -A testPaths=()
 for conf in "${configs[@]}"; do
-	## Next two line were modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+	## Next two line were modified by nginxproxy/acme-companion
   # shellcheck source=./config.sh
 	source "$conf"
 	## End of modifications
@@ -321,7 +321,7 @@ for dockerImage in "$@"; do
 	#version="${tagVar%-*}"
 	variant="${tagVar##*-}"
 
-	## Irrelevant code was removed here by jrcs/docker-letsencrypt-nginx-proxy-companion
+	## Irrelevant code was removed here by nginxproxy/acme-companion
 
 	testRepo="$repo"
 	if [ -z "$keepNamespace" ]; then
@@ -330,7 +330,7 @@ for dockerImage in "$@"; do
 	[ -z "${testAlias[$repo]}" ] || testRepo="${testAlias[$repo]}"
 
 	explicitVariant=
-	## Next four lines were modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+	## Next four lines were modified by nginxproxy/acme-companion
 	if [ "${explicitTests[:$variant]}" ] \
 	|| [ "${explicitTests[$repo:$variant]}" ] \
 	|| [ "${explicitTests[$testRepo:$variant]}" ]
@@ -367,14 +367,14 @@ for dockerImage in "$@"; do
 
 	tests=()
 	for t in "${testCandidates[@]}"; do
-		## Next line was modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+		## Next line was modified by nginxproxy/acme-companion
 		if [ ${#argTests[@]} -gt 0 ] && [ -z "${argTests[$t]}" ]; then
 		## End of modified code
 			# skipping due to -t
 			continue
 		fi
 
-		## Next seven lines were modified by jrcs/docker-letsencrypt-nginx-proxy-companion
+		## Next seven lines were modified by nginxproxy/acme-companion
 		if [ -n "${globalExcludeTests[${testRepo}_$t]}" ] \
 		|| [ -n "${globalExcludeTests[${testRepo}:${variant}_$t]}" ] \
 		|| [ -n "${globalExcludeTests[:${variant}_$t]}" ] \
@@ -401,7 +401,7 @@ for dockerImage in "$@"; do
 		scriptDir="${testPaths[$t]}"
 		if [ -d "$scriptDir" ]; then
 			script="$scriptDir/run.sh"
-			## Next nine lines were modified or added by jrcs/docker-letsencrypt-nginx-proxy-companion
+			## Next nine lines were modified or added by nginxproxy/acme-companion
 			if [ -x "$script" ] && [ ! -d "$script" ]; then
 				if [ $dryRun ]; then
 					if "$script" "$dockerImage"; then
@@ -416,7 +416,7 @@ for dockerImage in "$@"; do
 						if [ -f "$scriptDir/expected-std-out.txt" ] && ! d="$(echo "$output" | diff -u "$scriptDir/expected-std-out.txt" - 2>/dev/null)"; then
 							echo 'failed; unexpected output:'
 							echo "$d"
-							## Next line was added by jrcs/docker-letsencrypt-nginx-proxy-companion
+							## Next line was added by nginxproxy/acme-companion
 							failed_tests+=("$(basename "$scriptDir")")
 							## End of additional code
 							didFail=1
@@ -425,7 +425,7 @@ for dockerImage in "$@"; do
 						fi
 					else
 						echo 'failed'
-						## Next line was added by jrcs/docker-letsencrypt-nginx-proxy-companion
+						## Next line was added by nginxproxy/acme-companion
 						failed_tests+=("$(basename "$scriptDir")")
 						## End of additional code
 						didFail=1
@@ -447,7 +447,7 @@ for dockerImage in "$@"; do
 done
 
 if [ "$didFail" ]; then
-	## Next five lines were added by jrcs/docker-letsencrypt-nginx-proxy-companion
+	## Next five lines were added by nginxproxy/acme-companion
 	if [[ $GITHUB_ACTIONS == 'true' ]]; then
 		for test in "${failed_tests[@]}"; do
 			echo "$test" >> "$dir/github_actions/failed_tests.txt"

--- a/test/setup/docker-gen/Dockerfile
+++ b/test/setup/docker-gen/Dockerfile
@@ -32,6 +32,6 @@ ENV DOCKER_GEN_VERSION=0.7.4 \
 COPY --from=build-docker-gen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/
 
 # Get latest nginx.tmpl
-ADD https://raw.githubusercontent.com/jwilder/nginx-proxy/master/nginx.tmpl /etc/docker-gen/templates/
+ADD https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl /etc/docker-gen/templates/
 
 ENTRYPOINT ["/usr/local/bin/docker-gen"]

--- a/test/setup/docker-gen/Dockerfile
+++ b/test/setup/docker-gen/Dockerfile
@@ -24,7 +24,7 @@ FROM alpine:3.8
 
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com>"
 
-# DOCKER_GEN_VERSION environment variable is required by letsencrypt-nginx-proxy-companion
+# DOCKER_GEN_VERSION environment variable is required by acme-companion
 ENV DOCKER_GEN_VERSION=0.7.4 \
     DOCKER_HOST=unix:///tmp/docker.sock
 

--- a/test/setup/nginx-proxy/Dockerfile
+++ b/test/setup/nginx-proxy/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=go-builder /go/src/github.com/jwilder/docker-gen/docker-gen /usr/loc
 
 # Install nginx-proxy
 RUN mkdir /src /app \
-    && curl -sSL https://github.com/jwilder/nginx-proxy/archive/master.tar.gz \
+    && curl -sSL https://github.com/nginx-proxy/nginx-proxy/archive/master.tar.gz \
     | tar -C /src -xz \
     && cp /src/nginx-proxy-master/Procfile /app/ \
     && cp /src/nginx-proxy-master/dhparam.pem.default /app/ \

--- a/test/setup/nginx-proxy/Dockerfile
+++ b/test/setup/nginx-proxy/Dockerfile
@@ -31,7 +31,7 @@ FROM nginx:1.19-alpine
 
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com>"
 
-# DOCKER_GEN_VERSION environment variable is required by letsencrypt-nginx-proxy-companion
+# DOCKER_GEN_VERSION environment variable is required by acme-companion
 ENV DOCKER_GEN_VERSION=0.7.4 \
     DOCKER_HOST=unix:///tmp/docker.sock
 

--- a/test/setup/setup-nginx-proxy.sh
+++ b/test/setup/setup-nginx-proxy.sh
@@ -30,11 +30,11 @@ case $SETUP in
       -v /var/run/docker.sock:/tmp/docker.sock:ro \
       --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
       --network "$test_net" \
-      jwilder/nginx-proxy
+      nginxproxy/nginx-proxy
     ;;
 
   3containers)
-    curl https://raw.githubusercontent.com/jwilder/nginx-proxy/master/nginx.tmpl > "${GITHUB_WORKSPACE}/nginx.tmpl"
+    curl https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl > "${GITHUB_WORKSPACE}/nginx.tmpl"
 
     docker run -d -p 80:80 -p 443:443 \
       --name "$NGINX_CONTAINER_NAME" \

--- a/test/tests/certs_san/run.sh
+++ b/test/tests/certs_san/run.sh
@@ -28,9 +28,9 @@ function cleanup {
 trap cleanup EXIT
 
 # Create three different comma separated list from the first three domains in $domains.
-# testing for regression on spaced lists https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/issues/288
-# with trailing comma https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/issues/254
-# and with trailing dot https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/issues/676
+# testing for regression on spaced lists https://github.com/nginx-proxy/acme-companion/issues/288
+# with trailing comma https://github.com/nginx-proxy/acme-companion/issues/254
+# and with trailing dot https://github.com/nginx-proxy/acme-companion/issues/676
 letsencrypt_hosts=( \
   [0]="${domains[0]},${domains[1]},${domains[2]}" \     #straight comma separated list
   [1]="${domains[1]}, ${domains[2]}, ${domains[0]}" \   #comma separated list with spaces

--- a/test/tests/certs_single_domain/run.sh
+++ b/test/tests/certs_single_domain/run.sh
@@ -28,8 +28,8 @@ function cleanup {
 trap cleanup EXIT
 
 # Create three different comma separated list from the first three domains in $domains.
-# testing for regression on spaced lists https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/issues/288
-# and with trailing comma https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/issues/254
+# testing for regression on spaced lists https://github.com/nginx-proxy/acme-companion/issues/288
+# and with trailing comma https://github.com/nginx-proxy/acme-companion/issues/254
 letsencrypt_hosts=( \
   [0]="${domains[0]},${domains[1]},${domains[2]}" \     #straight comma separated list
   [1]="${domains[1]}, ${domains[2]}, ${domains[0]}" \   #comma separated list with spaces

--- a/test/tests/certs_standalone/run.sh
+++ b/test/tests/certs_standalone/run.sh
@@ -42,7 +42,7 @@ LETSENCRYPT_single_HOST=('${domains[0]}')
 EOF
 
 # Run an nginx container with a VIRTUAL_HOST set to a subdomain of ${domains[0]} in order to check for
-# this regression : https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/issues/674
+# this regression : https://github.com/nginx-proxy/acme-companion/issues/674
 if ! docker run --rm -d \
     --name "$subdomain" \
     -e "VIRTUAL_HOST=$subdomain" \

--- a/test/tests/docker_api/run.sh
+++ b/test/tests/docker_api/run.sh
@@ -37,13 +37,13 @@ case $SETUP in
   docker run --rm -d \
     --name "$nginx_vol" \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
-    jwilder/nginx-proxy > /dev/null
+    nginxproxy/nginx-proxy > /dev/null
 
   # Run a nginx-proxy container named nginx-env-var, without the nginx_proxy label
   docker run --rm -d \
     --name "$nginx_env" \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
-    jwilder/nginx-proxy > /dev/null
+    nginxproxy/nginx-proxy > /dev/null
 
   # This should target the nginx-proxy container obtained with
   # the --volume-from argument (nginx-volumes-from)
@@ -68,7 +68,7 @@ case $SETUP in
     --name "$nginx_lbl" \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
     --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
-    jwilder/nginx-proxy)"
+    nginxproxy/nginx-proxy)"
 
   # This should target the nginx-proxy container with the label (nginx-label)
   docker run --rm \

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -9,7 +9,7 @@ function get_base_domain {
 export -f get_base_domain
 
 
-# Run a letsencrypt-nginx-proxy-companion container
+# Run a acme-companion container
 function run_le_container {
   local image="${1:?}"
   local name="${2:?}"


### PR DESCRIPTION
This PR handles the renaming of the project to `nginx-proxy/acme-companion` (#768) and the use of the new DockerHub registry namespace [`nginxproxy`](https://hub.docker.com/u/nginxproxy) for the images.