### PR TITLE
chore: nginx-proxy default branch renamed to main

### DIFF
--- a/docs/Advanced-usage.md
+++ b/docs/Advanced-usage.md
@@ -6,10 +6,10 @@
 
 Please read and try [basic usage](./Basic-usage.md), and **validate that you have a working two containers setup** before using the three containers setup. In addition to the steps described there, running **nginx-proxy** as two separate containers with **acme-companion** requires the following:
 
-1) Download and mount the template file [nginx.tmpl](https://github.com/nginx-proxy/nginx-proxy/blob/master/nginx.tmpl) into the **docker-gen** container. You can get the nginx.tmpl file with a command like:
+1) Download and mount the template file [nginx.tmpl](https://github.com/nginx-proxy/nginx-proxy/blob/main/nginx.tmpl) into the **docker-gen** container. You can get the nginx.tmpl file with a command like:
 
 ```
-curl https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl > /path/to/nginx.tmpl
+curl https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/main/nginx.tmpl > /path/to/nginx.tmpl
 ```
 
 2) Use the `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` label on the **docker-gen** container, or explicitly set the `NGINX_DOCKER_GEN_CONTAINER` environment variable on the **acme-companion** container to the name or id of the **docker-gen** container (we'll use the later method in the example).

--- a/docs/Docker-Compose.md
+++ b/docs/Docker-Compose.md
@@ -106,7 +106,7 @@ volumes:
   acme:
 ```
 
-**Note:** don't forget to replace `/path/to/nginx.tmpl` with the actual path to the [`nginx.tmpl`](https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl) file you downloaded.
+**Note:** don't forget to replace `/path/to/nginx.tmpl` with the actual path to the [`nginx.tmpl`](https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/main/nginx.tmpl) file you downloaded.
 
 ### Other (external) examples
 

--- a/docs/Invalid-authorizations.md
+++ b/docs/Invalid-authorizations.md
@@ -54,7 +54,7 @@ Both are required. Every domain on `LETSENCRYPT_HOST`**must** be on `VIRTUAL_HOS
 
 #### you are using an outdated version of either **acme-companion** or the nginx.tmpl file (if running a 3 containers setup)
 
-Pull `nginxproxy/acme-companion:latest` again and get the latest [latest nginx.tmpl](https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl).
+Pull `nginxproxy/acme-companion:latest` again and get the latest [latest nginx.tmpl](https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/main/nginx.tmpl).
 
 
 ***

--- a/test/setup/docker-gen/Dockerfile
+++ b/test/setup/docker-gen/Dockerfile
@@ -32,6 +32,6 @@ ENV DOCKER_GEN_VERSION=0.7.4 \
 COPY --from=build-docker-gen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/
 
 # Get latest nginx.tmpl
-ADD https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl /etc/docker-gen/templates/
+ADD https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/main/nginx.tmpl /etc/docker-gen/templates/
 
 ENTRYPOINT ["/usr/local/bin/docker-gen"]

--- a/test/setup/nginx-proxy/Dockerfile
+++ b/test/setup/nginx-proxy/Dockerfile
@@ -53,14 +53,14 @@ COPY --from=go-builder /go/src/github.com/jwilder/docker-gen/docker-gen /usr/loc
 
 # Install nginx-proxy
 RUN mkdir /src /app \
-    && curl -sSL https://github.com/nginx-proxy/nginx-proxy/archive/master.tar.gz \
+    && curl -sSL https://github.com/nginx-proxy/nginx-proxy/archive/main.tar.gz \
     | tar -C /src -xz \
-    && cp /src/nginx-proxy-master/Procfile /app/ \
-    && cp /src/nginx-proxy-master/dhparam.pem.default /app/ \
-    && cp /src/nginx-proxy-master/docker-entrypoint.sh /app/ \
-    && cp /src/nginx-proxy-master/generate-dhparam.sh /app/ \
-    && cp /src/nginx-proxy-master/nginx.tmpl /app/ \
-    && cp /src/nginx-proxy-master/network_internal.conf /etc/nginx/ \
+    && cp /src/nginx-proxy-main/Procfile /app/ \
+    && cp /src/nginx-proxy-main/dhparam.pem.default /app/ \
+    && cp /src/nginx-proxy-main/docker-entrypoint.sh /app/ \
+    && cp /src/nginx-proxy-main/generate-dhparam.sh /app/ \
+    && cp /src/nginx-proxy-main/nginx.tmpl /app/ \
+    && cp /src/nginx-proxy-main/network_internal.conf /etc/nginx/ \
     && rm -rf /src
 
 WORKDIR /app

--- a/test/setup/setup-nginx-proxy.sh
+++ b/test/setup/setup-nginx-proxy.sh
@@ -34,7 +34,7 @@ case $SETUP in
     ;;
 
   3containers)
-    curl https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/master/nginx.tmpl > "${GITHUB_WORKSPACE}/nginx.tmpl"
+    curl https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/main/nginx.tmpl > "${GITHUB_WORKSPACE}/nginx.tmpl"
 
     docker run -d -p 80:80 -p 443:443 \
       --name "$NGINX_CONTAINER_NAME" \


### PR DESCRIPTION
This PR follows the renaming of `ninx-proxy`'s default branch from `master` to `main`.