### PR TITLE
Trim whitespaces from environment variables

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -152,7 +152,7 @@ function update_cert {
     params_issue_arr+=(--webroot /usr/share/nginx/html)
 
     local -n cert_keysize="LETSENCRYPT_${cid}_KEYSIZE"
-    if [[ -z "$cert_keysize" || "$cert_keysize" == "<no value>" ]] || \
+    if [[ -z "$cert_keysize" ]] || \
         [[ ! "$cert_keysize" =~ ^(2048|3072|4096|ec-256|ec-384)$ ]]; then
         cert_keysize=$DEFAULT_KEY_SIZE
     fi
@@ -168,7 +168,7 @@ function update_cert {
     local config_home
     # If we don't have a LETSENCRYPT_EMAIL from the proxied container
     # and DEFAULT_EMAIL is set to a non empty value, use the latter.
-    if [[ -z "$accountemail" || "$accountemail" == "<no value>" ]]; then
+    if [[ -z "$accountemail" ]]; then
         if [[ -n "${DEFAULT_EMAIL// }" ]]; then
             accountemail="$DEFAULT_EMAIL"
         else
@@ -184,7 +184,7 @@ function update_cert {
     fi 
 
     local -n acme_ca_uri="ACME_${cid}_CA_URI"
-    if [[ -z "$acme_ca_uri" || "$acme_ca_uri" == "<no value>" ]]; then
+    if [[ -z "$acme_ca_uri" ]]; then
         # Use default or user provided ACME end point
         acme_ca_uri="$ACME_CA_URI"
     fi
@@ -229,15 +229,15 @@ function update_cert {
         local -n eab_kid="ACME_${cid}_EAB_KID"
         local -n eab_hmac_key="ACME_${cid}_EAB_HMAC_KEY"
         local -n zerossl_api_key="ZEROSSL_${cid}_API_KEY"
-        if [[ -z "$zerossl_api_key" || "$zerossl_api_key" == "<no value>" ]]; then
+        if [[ -z "$zerossl_api_key" ]]; then
             # Try using the default API key
             zerossl_api_key="$ZEROSSL_API_KEY"
         fi
         if [[ ! -f "$account_file" ]]; then
-            if [[ -n "${eab_kid// }" && "$eab_kid" != "<no value>" && -n "${eab_hmac_key// }" && "$eab_hmac_key" != "<no value>" ]]; then
+            if [[ -n "${eab_kid}" && -n "${eab_hmac_key}" ]]; then
                 # Register the ACME account with the per container EAB credentials.
                 params_register_arr+=(--eab-kid "$eab_kid" --eab-hmac-key "$eab_hmac_key")
-            elif [[ -n "${zerossl_api_key// }" && "$zerossl_api_key" != "<no value>" ]]; then
+            elif [[ -n "${zerossl_api_key}" ]]; then
                 # We have a Zero SSL API key but no per-container EAB kid and hmac key.
                 # Generate a set of ACME EAB credentials using the ZeroSSL API.
                 local zerossl_api_response
@@ -293,7 +293,7 @@ function update_cert {
     fi
 
     local -n acme_preferred_chain="ACME_${cid}_PREFERRED_CHAIN"
-    if [[ -n "${acme_preferred_chain// }" && "$acme_preferred_chain" != "<no value>" ]]; then
+    if [[ -n "${acme_preferred_chain}" ]]; then
         # Using amce.sh --preferred-chain to select alternate chain.
         params_issue_arr+=(--preferred-chain "$acme_preferred_chain")
     fi

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -18,6 +18,16 @@ LETSENCRYPT_CONTAINERS=(
 {{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
     {{ $hosts := trimSuffix "," $hosts }}
     {{ range $container := $containers }}
+        {{ $KEYSIZE := trim (coalesce $container.Env.LETSENCRYPT_KEYSIZE "") }}
+        {{ $STAGING := trim (coalesce $container.Env.LETSENCRYPT_TEST "") }}
+        {{ $EMAIL := trim (coalesce $container.Env.LETSENCRYPT_EMAIL "") }}
+        {{ $CA_URI := trim (coalesce $container.Env.ACME_CA_URI "") }}
+        {{ $PREFERRED_CHAIN := trim (coalesce $container.Env.ACME_PREFERRED_CHAIN "") }}
+        {{ $OCSP := trim (coalesce $container.Env.ACME_OCSP "") }}
+        {{ $EAB_KID := trim (coalesce $container.Env.ACME_EAB_KID "") }}
+        {{ $EAB_HMAC_KEY := trim (coalesce $container.Env.ACME_EAB_HMAC_KEY "") }}
+        {{ $ZEROSSL_API_KEY := trim (coalesce $container.Env.ZEROSSL_API_KEY "") }}
+        {{ $RESTART_CONTAINER := trim (coalesce $container.Env.LETSENCRYPT_RESTART_CONTAINER "") }}
         {{ $cid := printf "%.12s" $container.ID }}
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
             {{ range $host := split $hosts "," }}
@@ -25,16 +35,16 @@ LETSENCRYPT_CONTAINERS=(
                 {{ $host := trimSuffix "." $host }}
                 {{ $hostHash := sha1 $host }}
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_HOST=('{{ $host }}')
-                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
-                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
-                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
-                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_CA_URI="{{ $container.Env.ACME_CA_URI }}"
-                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_PREFERRED_CHAIN="{{ $container.Env.ACME_PREFERRED_CHAIN }}"
-                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_OCSP="{{ $container.Env.ACME_OCSP }}"
-                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_EAB_KID="{{ $container.Env.ACME_EAB_KID }}"
-                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_EAB_HMAC_KEY="{{ $container.Env.ACME_EAB_HMAC_KEY }}"
-                {{- "\n" }}ZEROSSL_{{ $cid }}_{{ $hostHash }}_API_KEY="{{ $container.Env.ZEROSSL_API_KEY }}"
-                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $container.Env.LETSENCRYPT_RESTART_CONTAINER }}"
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_KEYSIZE="{{ $KEYSIZE }}"
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_TEST="{{ $STAGING }}"
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_EMAIL="{{ $EMAIL }}"
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_CA_URI="{{ $CA_URI }}"
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_PREFERRED_CHAIN="{{ $PREFERRED_CHAIN }}"
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_OCSP="{{ $OCSP }}"
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_EAB_KID="{{ $EAB_KID }}"
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_EAB_HMAC_KEY="{{ $EAB_HMAC_KEY }}"
+                {{- "\n" }}ZEROSSL_{{ $cid }}_{{ $hostHash }}_API_KEY="{{ $ZEROSSL_API_KEY }}"
+                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
             {{ end }}
         {{ else }}
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_HOST=( 
@@ -44,16 +54,16 @@ LETSENCRYPT_CONTAINERS=(
                         '{{ $host }}'{{ " " }} 
                     {{- end -}}
             )
-            {{- "\n" }}LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $container.Env.LETSENCRYPT_KEYSIZE }}"
-            {{- "\n" }}LETSENCRYPT_{{ $cid }}_TEST="{{ $container.Env.LETSENCRYPT_TEST }}"
-            {{- "\n" }}LETSENCRYPT_{{ $cid }}_EMAIL="{{ $container.Env.LETSENCRYPT_EMAIL }}"
-            {{- "\n" }}ACME_{{ $cid }}_CA_URI="{{ $container.Env.ACME_CA_URI }}"
-            {{- "\n" }}ACME_{{ $cid }}_PREFERRED_CHAIN="{{ $container.Env.ACME_PREFERRED_CHAIN }}"
-            {{- "\n" }}ACME_{{ $cid }}_OCSP="{{ $container.Env.ACME_OCSP }}"
-            {{- "\n" }}ACME_{{ $cid }}_EAB_KID="{{ $container.Env.ACME_EAB_KID }}"
-            {{- "\n" }}ACME_{{ $cid }}_EAB_HMAC_KEY="{{ $container.Env.ACME_EAB_HMAC_KEY }}"
-            {{- "\n" }}ZEROSSL_{{ $cid }}_API_KEY="{{ $container.Env.ZEROSSL_API_KEY }}"
-            {{- "\n" }}LETSENCRYPT_{{ $cid }}_RESTART_CONTAINER="{{ $container.Env.LETSENCRYPT_RESTART_CONTAINER }}"
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $KEYSIZE }}"
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_TEST="{{ $STAGING }}"
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_EMAIL="{{ $EMAIL }}"
+            {{- "\n" }}ACME_{{ $cid }}_CA_URI="{{ $CA_URI }}"
+            {{- "\n" }}ACME_{{ $cid }}_PREFERRED_CHAIN="{{ $PREFERRED_CHAIN }}"
+            {{- "\n" }}ACME_{{ $cid }}_OCSP="{{ $OCSP }}"
+            {{- "\n" }}ACME_{{ $cid }}_EAB_KID="{{ $EAB_KID }}"
+            {{- "\n" }}ACME_{{ $cid }}_EAB_HMAC_KEY="{{ $EAB_HMAC_KEY }}"
+            {{- "\n" }}ZEROSSL_{{ $cid }}_API_KEY="{{ $ZEROSSL_API_KEY }}"
+            {{- "\n" }}LETSENCRYPT_{{ $cid }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
         {{ end }}
     {{ end }}
 {{ end }}

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -3,11 +3,13 @@ LETSENCRYPT_CONTAINERS=(
         {{ if trim $hosts }}
             {{ range $container := $containers }}
                 {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
+                    {{/* Explicit per-domain splitting of the certificate */}}
                     {{ range $host := split $hosts "," }}
                         {{ $host := trim $host }}
                         {{- "\t"}}'{{ printf "%.12s" $container.ID }}_{{ sha1 $host }}'
                     {{ end }}
                 {{ else }}
+                    {{/* Default: multi-domain (SAN) certificate */}}
                     {{- "\t"}}'{{ printf "%.12s" $container.ID }}'
                 {{ end }}
             {{ end }}
@@ -18,6 +20,7 @@ LETSENCRYPT_CONTAINERS=(
 {{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
     {{ $hosts := trimSuffix "," $hosts }}
     {{ range $container := $containers }}
+        {{/* Trim spaces and set empty values on per-container environment variables */}}
         {{ $KEYSIZE := trim (coalesce $container.Env.LETSENCRYPT_KEYSIZE "") }}
         {{ $STAGING := trim (coalesce $container.Env.LETSENCRYPT_TEST "") }}
         {{ $EMAIL := trim (coalesce $container.Env.LETSENCRYPT_EMAIL "") }}
@@ -30,6 +33,7 @@ LETSENCRYPT_CONTAINERS=(
         {{ $RESTART_CONTAINER := trim (coalesce $container.Env.LETSENCRYPT_RESTART_CONTAINER "") }}
         {{ $cid := printf "%.12s" $container.ID }}
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
+            {{/* Explicit per-domain splitting of the certificate */}}
             {{ range $host := split $hosts "," }}
                 {{ $host := trim $host }}
                 {{ $host := trimSuffix "." $host }}
@@ -47,6 +51,7 @@ LETSENCRYPT_CONTAINERS=(
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
             {{ end }}
         {{ else }}
+            {{/* Default: multi-domain (SAN) certificate */}}
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_HOST=( 
                     {{- range $host := split $hosts "," }}
                         {{- $host := trim $host }}


### PR DESCRIPTION
This PR fixes #761 and prevents other errors of the same type.

Because white space trimming and default empty value are now done in the template, it simplifies variable checks in the service loop.