### PR TITLE
Fix small missing \ to make it copy pasteable

### DIFF
--- a/docs/Advanced-usage.md
+++ b/docs/Advanced-usage.md
@@ -72,7 +72,7 @@ $ docker run --detach \
 
 ```shell
 $ docker run --detach \
-    --name your-proxyed-app
+    --name your-proxyed-app \
     --env "VIRTUAL_HOST=subdomain.yourdomain.tld" \
     --env "LETSENCRYPT_HOST=subdomain.yourdomain.tld" \
     nginx


### PR DESCRIPTION
A \ was missing so pasting resulted in premature and incomplete execution.