### PR TITLE
Add `DEFAULT_KEY_SIZE` variable to the documentation

### DIFF
--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -50,7 +50,8 @@ The `LETSENCRYPT_EMAIL` environment variable must be a valid email and will be u
 
 #### Private key size
 
-The `LETSENCRYPT_KEYSIZE` environment variable determines the type and size of the requested key. Supported values are `2048`, `3072` and `4096` for RSA keys, and `ec-256` or `ec-384` for elliptic curve keys. The default is RSA 4096.
+The `LETSENCRYPT_KEYSIZE` environment variable determines the type and size of the requested key. Supported values are `2048`, `3072` and `4096` for RSA keys, and `ec-256` or `ec-384` for elliptic curve keys. The default is RSA 4096.  
+To change the global default set the `DEFAULT_KEY_SIZE` environment variable on the **acme-companion** container to one of the supported values specified above.
 
 #### OCSP stapling
 


### PR DESCRIPTION
Useful but undocumented environment variable to avoid setting `LETSENCRYPT_KEYSIZE` on every container manually