### PR TITLE
Bump acme.sh version to 2.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM alpine:3.13.5
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com> (@buchdag)"
 
 ARG GIT_DESCRIBE
-ARG ACMESH_VERSION=2.8.8
+ARG ACMESH_VERSION=2.9.0
 
 ENV COMPANION_VERSION=$GIT_DESCRIBE \
     DOCKER_HOST=unix:///var/run/docker.sock \


### PR DESCRIPTION
Self explanatory.

Should fix a bug that prevented upgrade of the `alpine` version.