### PR TITLE
Wildcard certificate support with CloudFlare DNS

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -53,7 +53,7 @@ function ascending_wildcard_locations {
     # - *.example.com
     local domain="${1:?}"
     local first_label
-    regex="^[[:alnum:]_\-]+(\.[[:alpha:]]+)?$"
+    regex="^(\*\.)?[[:alnum:]_\-]+(\.[[:alpha:]]+)?$"
     until [[ "$domain" =~ $regex ]]; do
       first_label="${domain%%.*}"
       domain="${domain/${first_label}./}"
@@ -73,7 +73,7 @@ function descending_wildcard_locations {
     # - foo.*
     local domain="${1:?}"
     local last_label
-    regex="^[[:alnum:]_\-]+$"
+    regex="^(\*\.)?[[:alnum:]_\-]+$"
     until [[ "$domain" =~ $regex ]]; do
       last_label="${domain##*.}"
       domain="${domain/.${last_label}/}"

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -149,7 +149,7 @@ function update_cert {
 
     # CLI parameters array used for --issue
     local -a params_issue_arr
-    params_issue_arr+=(--webroot /usr/share/nginx/html)
+    [[ -z "${CF_Token}" ]] && params_issue_arr+=(--webroot /usr/share/nginx/html) || params_issue_arr+=(--dns dns_cf)
 
     local -n cert_keysize="LETSENCRYPT_${cid}_KEYSIZE"
     if [[ -z "$cert_keysize" ]] || \


### PR DESCRIPTION
Edited a few lines in **/app/letsencrypt_service** and **/app/functions.sh** to create wildcard certificate for domain. As of now it only supports wildcard certificate creation over CloudFlare dns and I tested it with:

`ACME_CA_URI = "https://acme.zerossl.com/v2/DV90"`

In docker-compose.yml it specified it this way:
```
version: "3.5"
services:`
......
  nginx:
    image: ${NGINX_IMAGE}
    container_name: ${NGINX_CONTAINER_NAME}
    restart: always
    ports:
      - ${PORT1}
      - ${PORT2}
    volumes:
      - ${VOLUME1}
      - ${VOLUME2}
      - ${VOLUME3}
      - ${VOLUME4}
  acme:
    image: ${ACME_IMAGE}
    container_name: ${ACME_CONTAINER_NAME}
    restart: always
    environment:
      - DEFAULT_EMAIL=${DEFAULT_EMAIL}
      - CF_Token=${CF_TOKEN}
      - CF_Account_ID=${CF_ACCOUNT_ID}
      - CF_Zone_ID=${CF_ZONE_ID}
      - ACME_CA_URI=${ACME_CA_URI}
      - DEBUG=1
    depends_on:
      - nginx
    volumes_from:
      - nginx:rw
    volumes:
      - ${VOLUME5}
      - ${VOLUME6}
.....
```

.env file:
```
.....
ACME_CA_URI="https://acme.zerossl.com/v2/DV90"
.....
VOLUME1=certs:/etc/nginx/certs
VOLUME2=vhost:/etc/nginx/vhost.d
VOLUME3=html:/usr/share/nginx/html
VOLUME4=/var/run/docker.sock:/tmp/docker.sock:ro
VOLUME5=/var/run/docker.sock:/var/run/docker.sock:ro
VOLUME6=acme:/etc/acme.sh
.....
```

And finally token permissions in CloudFlare:
![image](https://user-images.githubusercontent.com/98539622/151399184-cce45168-0f9d-4bfc-b25d-787a68775536.png)
