### PR TITLE
Added DEFAULT_EMAIL env variable to docker-compose docs

### DIFF
--- a/docs/Docker-Compose.md
+++ b/docs/Docker-Compose.md
@@ -21,6 +21,8 @@ services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy
     container_name: nginx-proxy
+    environment:
+      - DEFAULT_EMAIL=mail@yourdomain.tld
     ports:
       - "80:80"
       - "443:443"
@@ -60,6 +62,8 @@ services:
   nginx-proxy:
     image: nginx:alpine
     container_name: nginx-proxy
+    environment:
+      - DEFAULT_EMAIL=mail@yourdomain.tld
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
I noticed the readme.md includes an env variable for the letsencrypt email so you can be notified if your certs are about to expire(they should automatically renew with this anyway but still) but the docker-compose doesn't so I thought it might be worth to add it there too

![image](https://user-images.githubusercontent.com/90116640/154569550-3e932038-305a-4e3e-b037-0bb38ef00e98.png)
![image](https://user-images.githubusercontent.com/90116640/154569574-7a99bd02-3a1c-4a43-8f62-7a08b96e3a11.png)
