### PR TITLE
add 5s:30s to -wait

### DIFF
--- a/docs/Docker-Compose.md
+++ b/docs/Docker-Compose.md
@@ -75,7 +75,7 @@ services:
   docker-gen:
     image: nginxproxy/docker-gen
     container_name: nginx-proxy-gen
-    command: -notify-sighup nginx-proxy -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    command: -notify-sighup nginx-proxy -watch 5s:30s /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
     volumes_from:
       - nginx-proxy
     volumes:


### PR DESCRIPTION
In the [Advanced Usage doc](https://github.com/nginx-proxy/acme-companion/blob/main/docs/Advanced-usage.md#step-2---docker-gen), the there is `5s:30s` specified after `-wait`. In this doc it was missing. For completeness I have added it here.