### PR TITLE
ci: fix boulder integration tests

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build Image
         run: docker build -t "$IMAGE" .
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout Docker official images tests
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: docker-library/official-images
           path: official-images
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # PREPARE RUNNER ENV
       - name: Add Test Domains in /etc/hosts

--- a/test/setup/setup-boulder.sh
+++ b/test/setup/setup-boulder.sh
@@ -10,7 +10,7 @@ setup_boulder() {
     && git clone https://github.com/letsencrypt/boulder \
       "$GOPATH/src/github.com/letsencrypt/boulder"
   pushd "$GOPATH/src/github.com/letsencrypt/boulder"
-  git checkout release-2020-12-14
+  git checkout release-2022-11-29
   if [[ "$(uname)" == 'Darwin' ]]; then
     # Set Standard Ports
     for file in test/config/va.json test/config/va-remote-a.json test/config/va-remote-b.json; do

--- a/test/setup/setup-local.sh
+++ b/test/setup/setup-local.sh
@@ -128,9 +128,11 @@ EOF
 
     if [[ "$ACME_CA" == 'boulder' ]]; then
       # Stop and remove boulder
+      docker stop boulder
       docker-compose --project-name 'boulder' \
         --file "${GITHUB_WORKSPACE}/go/src/github.com/letsencrypt/boulder/docker-compose.yml" \
         down --volumes
+      docker rm boulder
     elif [[ "$ACME_CA" == 'pebble' ]]; then
       docker network rm acme_net
       [[ -f "${GITHUB_WORKSPACE}/pebble.minica.pem" ]] && rm "${GITHUB_WORKSPACE}/pebble.minica.pem"


### PR DESCRIPTION
This fix the two `ocsp_must_staple` tests that rely on Boulder rather than Pebble.