### PR TITLE
ci: add GitHub Actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   # Maintain dependencies for Docker
   - package-ecosystem: "docker"
     directory: "/"
@@ -10,3 +9,13 @@ updates:
       prefix: "build"
     labels:
       - "type/build"
+
+  # Maintain GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "type/ci"


### PR DESCRIPTION
This PR add GitHub Actions ecosystem to Dependabot.