### PR TITLE
refactor: move to correctly namespaced labels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,7 @@ jobs:
         test-name:
           [
             docker_api,
+            docker_api_legacy,
             location_config,
             certs_single,
             certs_san,

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
+.docker
+.vscode
 certs/
 conf.d/
 data/
 vhost.d/
-.vscode
 
 # tests
 go/

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -157,13 +157,13 @@ if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
         echo "Check that you are doing one of the following :" >&2
         echo -e "\t- Use the --volumes-from option to mount volumes from the nginx-proxy container." >&2
         echo -e "\t- Set the NGINX_PROXY_CONTAINER env var on the letsencrypt-companion container to the name of the nginx-proxy container." >&2
-        echo -e "\t- Label the nginx-proxy container to use with 'com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy'." >&2
+        echo -e "\t- Label the nginx-proxy container to use with 'com.github.nginx-proxy.nginx'." >&2
         exit 1
     elif [[ -z "$(get_docker_gen_container)" ]] && ! is_docker_gen_container "$(get_nginx_proxy_container)"; then
         echo "Error: can't get docker-gen container id !" >&2
         echo "If you are running a three containers setup, check that you are doing one of the following :" >&2
         echo -e "\t- Set the NGINX_DOCKER_GEN_CONTAINER env var on the letsencrypt-companion container to the name of the docker-gen container." >&2
-        echo -e "\t- Label the docker-gen container to use with 'com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen'." >&2
+        echo -e "\t- Label the docker-gen container to use with 'com.github.nginx-proxy.docker-gen'." >&2
         exit 1
     fi
     check_writable_directory '/etc/nginx/certs'

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -278,7 +278,9 @@ function is_docker_gen_container {
 
 function get_docker_gen_container {
     # First try to get the docker-gen container ID from the container label.
-    local docker_gen_cid; docker_gen_cid="$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen)"
+    local legacy_docker_gen_cid; legacy_docker_gen_cid="$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen)"
+    local new_docker_gen_cid; new_docker_gen_cid="$(labeled_cid com.github.nginx-proxy.docker-gen)"
+    local docker_gen_cid; docker_gen_cid="${new_docker_gen_cid:-$legacy_docker_gen_cid}"
 
     # If the labeled_cid function dit not return anything and the env var is set, use it.
     if [[ -z "$docker_gen_cid" ]] && [[ -n "${NGINX_DOCKER_GEN_CONTAINER:-}" ]]; then
@@ -292,7 +294,9 @@ function get_docker_gen_container {
 function get_nginx_proxy_container {
     local volumes_from
     # First try to get the nginx container ID from the container label.
-    local nginx_cid; nginx_cid="$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy)"
+    local legacy_nginx_cid; legacy_nginx_cid="$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy)"
+    local new_nginx_cid; new_nginx_cid="$(labeled_cid com.github.nginx-proxy.nginx)"
+    local nginx_cid; nginx_cid="${new_nginx_cid:-$legacy_nginx_cid}"
 
     # If the labeled_cid function dit not return anything ...
     if [[ -z "${nginx_cid}" ]]; then

--- a/docs/Advanced-usage.md
+++ b/docs/Advanced-usage.md
@@ -10,7 +10,7 @@ Please read and try [basic usage](./Basic-usage.md), and **validate that you hav
 curl https://raw.githubusercontent.com/nginx-proxy/nginx-proxy/main/nginx.tmpl > /path/to/nginx.tmpl
 ```
 
-2) Use the `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` label on the **docker-gen** container, or explicitly set the `NGINX_DOCKER_GEN_CONTAINER` environment variable on the **acme-companion** container to the name or id of the **docker-gen** container (we'll use the later method in the example).
+2) Use the `com.github.nginx-proxy.docker-gen` label on the **docker-gen** container, or explicitly set the `NGINX_DOCKER_GEN_CONTAINER` environment variable on the **acme-companion** container to the name or id of the **docker-gen** container (we'll use the later method in the example).
 
 3) Declare `/etc/nginx/conf.d` as a volume on the nginx container so that it can be shared with the **docker-gen** container.
 

--- a/docs/Docker-Compose.md
+++ b/docs/Docker-Compose.md
@@ -82,7 +82,7 @@ services:
       - /path/to/nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
     labels:
-      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen"
+      - "com.github.nginx-proxy.docker-gen"
     network_mode: bridge
 
   acme-companion:

--- a/docs/Getting-containers-IDs.md
+++ b/docs/Getting-containers-IDs.md
@@ -4,7 +4,7 @@ For **acme-companion** to work properly, it needs to know the ID of the **nginx*
 
 There are three methods to inform the **acme-companion** container of the **nginx**/**nginx-proxy** container ID:
 
-* `label` method: add the label `com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy` to the **nginx**/**nginx-proxy** container.
+* `label` method: add the label `com.github.nginx-proxy.nginx` to the **nginx**/**nginx-proxy** container.
 
 * `environment variable` method: assign a fixed name to the **nginx**/**nginx-proxy** container with `container_name:` and set the environment variable `NGINX_PROXY_CONTAINER` to this name on the **acme-companion** container.
 
@@ -12,7 +12,7 @@ There are three methods to inform the **acme-companion** container of the **ngin
 
 And two methods to inform the **acme-companion** container of the **docker-gen** container ID:
 
-* `label` method: add the label `com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen` to the **docker-gen** container.
+* `label` method: add the label `com.github.nginx-proxy.docker-gen` to the **docker-gen** container.
 
 * `environment variable` method: assign a fixed name to the **docker-gen** container with `container_name:` and set the environment variable `NGINX_DOCKER_GEN_CONTAINER` to this name on the **acme-companion** container.
 
@@ -26,12 +26,12 @@ The advantage the `label` methods have over the `environment variable` (and `vol
 ```
 $ docker run --detach \
     [...]
-    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
+    --label com.github.nginx-proxy.nginx \
     nginx
 
 $ docker run --detach \
     [...]
-    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen \
+    --label com.github.nginx-proxy.docker-gen \
     nginxproxy/docker-gen
 
 $ docker run --detach \
@@ -67,7 +67,7 @@ $ docker run --detach \
 
 $ docker run --detach \
     [...]
-    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen \
+    --label com.github.nginx-proxy.docker-gen \
     nginxproxy/docker-gen
 
 $ docker run --detach \

--- a/test/config.sh
+++ b/test/config.sh
@@ -3,6 +3,7 @@ set -e
 
 globalTests+=(
 	docker_api
+	docker_api_legacy
 	location_config
 	default_cert
 	certs_single

--- a/test/setup/setup-local.sh
+++ b/test/setup/setup-local.sh
@@ -130,7 +130,7 @@ EOF
     get_environment
 
     # Stop and remove nginx-proxy and (if required) docker-gen
-    for cid in $(docker ps -a --filter "label=com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite" --format "{{.ID}}"); do
+    for cid in $(docker ps -a --filter "label=com.github.nginx-proxy.acme-companion.test-suite" --format "{{.ID}}"); do
       docker stop "$cid"
       docker rm --volumes "$cid"
     done

--- a/test/setup/setup-nginx-proxy.sh
+++ b/test/setup/setup-nginx-proxy.sh
@@ -28,7 +28,7 @@ case $SETUP in
       -v /etc/nginx/vhost.d \
       -v /usr/share/nginx/html \
       -v /var/run/docker.sock:/tmp/docker.sock:ro \
-      --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
+      --label com.github.nginx-proxy.acme-companion.test-suite \
       --network "$test_net" \
       nginxproxy/nginx-proxy
     ;;
@@ -42,7 +42,7 @@ case $SETUP in
       -v /etc/nginx/conf.d \
       -v /etc/nginx/vhost.d \
       -v /usr/share/nginx/html \
-      --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
+      --label com.github.nginx-proxy.acme-companion.test-suite \
       --network "$test_net" \
       nginx:alpine
 
@@ -51,7 +51,7 @@ case $SETUP in
       --volumes-from "$NGINX_CONTAINER_NAME" \
       -v "${GITHUB_WORKSPACE}/nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro" \
       -v /var/run/docker.sock:/tmp/docker.sock:ro \
-      --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
+      --label com.github.nginx-proxy.acme-companion.test-suite \
       --network "$test_net" \
       nginxproxy/docker-gen \
       -notify-sighup "$NGINX_CONTAINER_NAME" -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf

--- a/test/tests/docker_api_legacy/run.sh
+++ b/test/tests/docker_api_legacy/run.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-## Test for the Docker API.
+## Test for the Docker API with legacy labels.
 
-nginx_vol='nginx-volumes-from'
-nginx_env='nginx-env-var'
-nginx_lbl='nginx-label'
-docker_gen='docker-gen-no-label'
-docker_gen_lbl='docker-gen-label'
+nginx_vol='nginx-volumes-from-legacy'
+nginx_env='nginx-env-var-legacy'
+nginx_lbl='nginx-label-legacy'
+docker_gen='docker-gen-no-label-legacy'
+docker_gen_lbl='docker-gen-label-legacy'
 
 case $SETUP in
 
@@ -67,7 +67,7 @@ case $SETUP in
   labeled_nginx_cid="$(docker run --rm -d \
     --name "$nginx_lbl" \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
-    --label com.github.nginx-proxy.nginx \
+    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
     nginxproxy/nginx-proxy)"
 
   # This should target the nginx-proxy container with the label (nginx-label)
@@ -78,7 +78,7 @@ case $SETUP in
     "$1" \
     bash -c "$commands" 2>&1
 
-  cat > "${GITHUB_WORKSPACE}/test/tests/docker_api/expected-std-out.txt" <<EOF
+  cat > "${GITHUB_WORKSPACE}/test/tests/docker_api_legacy/expected-std-out.txt" <<EOF
 Container $nginx_vol received exec_start: sh -c /app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
 $nginx_vol
 Container $nginx_env received exec_start: sh -c /app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload
@@ -156,7 +156,7 @@ EOF
   # Spawn a nginx container named nginx-label, with the nginx_proxy label.
   labeled_nginx1_cid="$(docker run --rm -d \
     --name "$nginx_lbl" \
-    --label com.github.nginx-proxy.nginx \
+    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
     nginx:alpine)"
 
   # This should target the nginx container whose id or name was obtained with
@@ -176,7 +176,7 @@ EOF
   # Spawn a "fake docker-gen" container named docker-gen-label, with the docker_gen label.
   labeled_docker_gen_cid="$(docker run --rm -d \
     --name "$docker_gen_lbl" \
-    --label com.github.nginx-proxy.docker-gen \
+    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen \
     nginx:alpine)"
 
   # This should target the nginx container whose id or name was obtained with
@@ -205,7 +205,7 @@ EOF
   # Spawn a nginx container named nginx-label, with the nginx_proxy label.
   labeled_nginx2_cid="$(docker run --rm -d \
     --name "$nginx_lbl" \
-    --label com.github.nginx-proxy.nginx \
+    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy \
     nginx:alpine)"
 
   # This should target the nginx container whose id or name was obtained with
@@ -220,7 +220,7 @@ EOF
     "$1" \
     bash -c "$commands" 2>&1
 
-    cat > "${GITHUB_WORKSPACE}/test/tests/docker_api/expected-std-out.txt" <<EOF
+    cat > "${GITHUB_WORKSPACE}/test/tests/docker_api_legacy/expected-std-out.txt" <<EOF
 Container $docker_gen received signal 1
 Container $nginx_vol received signal 1
 $docker_gen

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -63,7 +63,7 @@ function run_le_container {
     --env "DOCKER_GEN_WAIT=500ms:2s" \
     --env "TEST_MODE=true" \
     --env "DEBUG=1" \
-    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
+    --label com.github.nginx-proxy.acme-companion.test-suite \
     "$image" > /dev/null; \
   then
     [[ "${DRY_RUN:-}" == 1 ]] && echo "Started letsencrypt container for test ${name%%_2*}"
@@ -122,7 +122,7 @@ function run_nginx_container {
     --name "${container_name:-$virtual_host}" \
     -e "VIRTUAL_HOST=$virtual_host" \
     -e "LETSENCRYPT_HOST=$le_host" \
-    --label com.github.jrcs.letsencrypt_nginx_proxy_companion.test_suite \
+    --label com.github.nginx-proxy.acme-companion.test-suite \
     "${cli_args_arr[@]}" \
     nginx:alpine > /dev/null ; \
   then


### PR DESCRIPTION
This PR basically rename the old `com.github.jrcs.letsencrypt_nginx_proxy_companion.x` labels to `com.github.nginx-proxy.x` labels, while keeping backward compatibility with the legacy labels.