### PR TITLE
Upgrade acme.sh to version 3.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM nginxproxy/docker-gen:0.10.6 AS docker-gen
 FROM alpine:3.18.3
 
 ARG GIT_DESCRIBE
-ARG ACMESH_VERSION=2.9.0
+ARG ACMESH_VERSION=3.0.7
 
 ENV COMPANION_VERSION=$GIT_DESCRIBE \
     DOCKER_HOST=unix:///var/run/docker.sock \

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -222,7 +222,14 @@ function update_cert {
 
     [[ ! -d "$config_home" ]] && mkdir -p "$config_home"
     params_base_arr+=(--config-home "$config_home")
-    local account_file="${config_home}/ca/${ca_dir}/account.json"
+    local account_file="${config_home}/ca/${ca_dir}/directory/account.json"
+    local account_dir="${account_file%/*}"
+
+    # Account path moved to sub directory 'directory' with acme.sh 3.0.0
+    local old_account_file="${config_home}/ca/${ca_dir}/account.json"
+    if [[ -f "$old_account_file" ]] && [[ ! -e "$account_dir" ]]; then
+        ln -s . "$account_dir"
+    fi
 
     # External Account Binding (EAB)
     local -n eab_kid="ACME_${cid}_EAB_KID"

--- a/install_acme.sh
+++ b/install_acme.sh
@@ -7,7 +7,7 @@ apk --no-cache --virtual .acmesh-deps add git
 
 # Get acme.sh ACME client source
 mkdir /src
-git -C /src clone https://github.com/Neilpang/acme.sh.git
+git -C /src clone https://github.com/acmesh-official/acme.sh.git
 cd /src/acme.sh
 if [[ "$ACMESH_VERSION" != "master" ]]; then
   git -c advice.detachedHead=false checkout "$ACMESH_VERSION"


### PR DESCRIPTION
to benefit from last improvements of script dnsapi/dns_gandi_livedns.sh.