### PR TITLE
fix: prevent infinite loop in enumerate_wildcard_locations

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -62,11 +62,12 @@ function ascending_wildcard_locations {
     # - *.example.com
     local domain="${1:?}"
     local first_label
-    regex="^[[:alnum:]_\-]+(\.[[:alpha:]]+)?$"
-    until [[ "$domain" =~ $regex ]]; do
+    tld_regex="^[[:alpha:]]+$"
+    regex="^[^.]+\..+$"
+    while [[ "$domain" =~ $regex ]]; do
       first_label="${domain%%.*}"
-      domain="${domain/${first_label}./}"
-      if [[ -z "$domain" ]]; then
+      domain="${domain/#"${first_label}."/}"
+      if [[ "$domain" == "*" || "$domain" =~ $tld_regex ]]; then
         return
       else
         echo "*.${domain}"
@@ -82,11 +83,11 @@ function descending_wildcard_locations {
     # - foo.*
     local domain="${1:?}"
     local last_label
-    regex="^[[:alnum:]_\-]+$"
-    until [[ "$domain" =~ $regex ]]; do
+    regex="^.+\.[^.]+$"
+    while [[ "$domain" =~ $regex ]]; do
       last_label="${domain##*.}"
-      domain="${domain/.${last_label}/}"
-      if [[ -z "$domain" ]]; then
+      domain="${domain/%".${last_label}"/}"
+      if [[ "$domain" == "*" ]]; then
         return
       else
         echo "${domain}.*"


### PR DESCRIPTION
This pull request fixes two issues in `enumerate_wildcard_locations` function:

1) When a wildcard domain passed to the function, it never returns. Even though wildcard domains are not supported at the moment, I think, infinite loop should be fixed. Currently any wildcard domain in any container configuration completely hangs the service. 
2) In `descending_wildcard_locations` the first occurrence of `last_label` was removed, which might generate wrong wildcards:
```bash
#!/bin/bash

source ./functions.sh
enumerate_wildcard_locations test.com.example.com

# Output:
# *.com.example.com
# *.example.com
# test.example.com.*  <-- should be test.com.example.*
# test.example.*      <-- should be test.com.*
# test.*
```
