### PR TITLE
test: bump boulder to release-2023-12-04

### DIFF
--- a/test/setup/setup-boulder.sh
+++ b/test/setup/setup-boulder.sh
@@ -10,7 +10,7 @@ setup_boulder() {
     && git clone https://github.com/letsencrypt/boulder \
       "$GOPATH/src/github.com/letsencrypt/boulder"
   pushd "$GOPATH/src/github.com/letsencrypt/boulder"
-  git checkout release-2023-01-09
+  git checkout release-2023-12-04
   if [[ "$(uname)" == 'Darwin' ]]; then
     # Set Standard Ports
     for file in test/config/va.json test/config/va-remote-a.json test/config/va-remote-b.json; do


### PR DESCRIPTION
Attempt to fix the failing OCSP test, which are the only ones that rely on Boulder rather than Pebble.