### PR TITLE
fix: dot not remove symlinked default certificate / private key

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -56,12 +56,13 @@ function cleanup_links {
     local -a SYMLINKED_DOMAINS
     local -a DISABLED_DOMAINS
 
-    # Create an array containing domains for which a
-    # symlinked private key exists in /etc/nginx/certs.
+    # Create an array containing domains for which a symlinked certificate
+    # exists in /etc/nginx/certs (excluding default cert).
     for symlinked_domain in /etc/nginx/certs/*.crt; do
         [[ -L "$symlinked_domain" ]] || continue
         symlinked_domain="${symlinked_domain##*/}"
         symlinked_domain="${symlinked_domain%*.crt}"
+        [[ "$symlinked_domain" != "default" ]] || continue
         SYMLINKED_DOMAINS+=("$symlinked_domain")
     done
     [[ "$DEBUG" == 1 ]] && echo "Symlinked domains: ${SYMLINKED_DOMAINS[*]}"

--- a/test/tests/symlinks/run.sh
+++ b/test/tests/symlinks/run.sh
@@ -47,6 +47,11 @@ docker exec "$le_container_name" cp /etc/nginx/certs/le1.wtf/key.pem /etc/nginx/
 docker exec "$le_container_name" bash -c 'cd /etc/nginx/certs; ln -s ./le4.wtf/fullchain.pem ./le4.wtf.crt'
 docker exec "$le_container_name" bash -c 'cd /etc/nginx/certs; ln -s ./le4.wtf/key.pem ./le4.wtf.key'
 
+# symlink default certificate to le1.wtf certificate
+docker exec "$le_container_name" rm -f /etc/nginx/certs/default.crt /etc/nginx/certs/default.key
+docker exec "$le_container_name" bash -c 'cd /etc/nginx/certs; ln -s ./le1.wtf/fullchain.pem ./default.crt'
+docker exec "$le_container_name" bash -c 'cd /etc/nginx/certs; ln -s ./le1.wtf/key.pem ./default.key'
+
 # Stop the nginx containers for ${domains[0]} and ${domains[1]} silently,
 # then check if the corresponding symlinks are removed.
 docker stop "symlink-le1-le2" > /dev/null
@@ -108,3 +113,7 @@ docker stop "symlink-lim-le2" > /dev/null
 # Check if the custom certificate is still there
 docker exec "$le_container_name" [ -f /etc/nginx/certs/le4.wtf.crt ] \
   || echo "Custom certificate for le4.wtf was removed."
+
+# Check if the default certificate is still there
+docker exec "$le_container_name" [ -f /etc/nginx/certs/default.crt ] \
+  || echo "Default certificate was removed."


### PR DESCRIPTION
If `default.crt` / `default.key` were symlinks to certificates managed by this container, they were removed along other symlinks in `/etc/nginx/certs`. This was an unintentional behaviour.