### PR TITLE
ci: bump upload & download artifact actions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: docker save $IMAGE > companion.tar
 
       - name: Upload Image Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: companion.tar
           path: companion.tar
@@ -60,7 +60,7 @@ jobs:
           path: official-images
 
       - name: Download Builded Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: companion.tar
 
@@ -150,7 +150,7 @@ jobs:
 
       # ADD BUILT IMAGE
       - name: Download Built Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: companion.tar
 


### PR DESCRIPTION
Blocked until https://github.com/actions/download-artifact/issues/249 is fixed.