### PR TITLE
build: use custom user agent string

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,13 @@ FROM nginxproxy/docker-gen:0.11.1 AS docker-gen
 
 FROM alpine:3.19.0
 
-ARG GIT_DESCRIBE
+ARG GIT_DESCRIBE="unknown"
 ARG ACMESH_VERSION=3.0.7
 
-ENV COMPANION_VERSION=$GIT_DESCRIBE \
+ENV ACMESH_VERSION=${ACMESH_VERSION} \
+    COMPANION_VERSION=${GIT_DESCRIBE} \
     DOCKER_HOST=unix:///var/run/docker.sock \
-    PATH=$PATH:/app
+    PATH=${PATH}:/app
 
 # Install packages required by the image
 RUN apk add --no-cache --virtual .bin-deps \

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -133,6 +133,7 @@ function update_cert {
     # Base CLI parameters array, used for both --register-account and --issue
     local -a params_base_arr
     params_base_arr+=(--log /dev/null)
+    params_base_arr+=(--useragent "nginx-proxy/acme-companion/$COMPANION_VERSION (acme.sh/$ACMESH_VERSION)")
     [[ "$DEBUG" == 1 ]] && params_base_arr+=(--debug 2)
 
     # Alternative trusted root CA path, used for test with Pebble


### PR DESCRIPTION
The PR customise the user agent string provided by acme.sh, adding the acme-companion version.