### PR TITLE
fix: get container ID from /proc/self/mountinfo (for podman)

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -199,14 +199,14 @@ function get_self_cid {
 
     # Try the /proc files methods first then resort to the Docker API.
     if [[ -f /proc/1/cpuset ]]; then
-        self_cid="$(grep -Eo '[[:alnum:]]{64}' /proc/1/cpuset)"
+        self_cid="$(grep -Eo -m 1 '[[:alnum:]]{64}' /proc/1/cpuset)"
     fi
     if [[ ( ${#self_cid} != 64 ) && ( -f /proc/self/cgroup ) ]]; then
         self_cid="$(grep -Eo -m 1 '[[:alnum:]]{64}' /proc/self/cgroup)"
     fi
     # cgroups v2
     if [[ ( ${#self_cid} != 64 ) && ( -f /proc/self/mountinfo ) ]]; then
-        self_cid="$(grep '/userdata/hostname' /proc/self/mountinfo | grep -Eo '[[:alnum:]]{64}')"
+        self_cid="$(grep '/userdata/hostname' /proc/self/mountinfo | grep -Eo -m 1 '[[:alnum:]]{64}')"
     fi
     if [[ ( ${#self_cid} != 64 ) ]]; then
         self_cid="$(docker_api "/containers/$(hostname)/json" | jq -r '.Id')"

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -204,6 +204,10 @@ function get_self_cid {
     if [[ ( ${#self_cid} != 64 ) && ( -f /proc/self/cgroup ) ]]; then
         self_cid="$(grep -Eo -m 1 '[[:alnum:]]{64}' /proc/self/cgroup)"
     fi
+    # cgroups v2
+    if [[ ( ${#self_cid} != 64 ) && ( -f /proc/self/mountinfo ) ]]; then
+        self_cid="$(grep '/userdata/hostname' /proc/self/mountinfo | grep -Eo '[[:alnum:]]{64}')"
+    fi
     if [[ ( ${#self_cid} != 64 ) ]]; then
         self_cid="$(docker_api "/containers/$(hostname)/json" | jq -r '.Id')"
     fi


### PR DESCRIPTION
With cgroup v2, CID can be read from /proc/self/mountinfo

OCI specification defines that hostname must be set with UTS namespace.
http://wking.github.io/opencontainer-runtime-spec/#_hostname

Podman set the hostname of container running in a pod to a name of pod, e.g. 'test-pod', not a container ID, e.g. '1cb364360e42'.
Docker API via /tmp/docker.sock linked to /var/run/podman.sock returns error as following.
{"cause":"no such container","message":"\"test-pod\" is a pod, not a container: no such container","response":404}

Need to get container ID from /proc/self/mountinfo from the container inside if the container is running in a pod by Podman.