### PR TITLE
ci: bump artifact actions  from 3 to 4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: docker save $IMAGE > companion.tar
 
       - name: Upload Image Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: companion.tar
           path: companion.tar
@@ -60,7 +60,7 @@ jobs:
           path: official-images
 
       - name: Download Builded Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: companion.tar
 
@@ -108,7 +108,7 @@ jobs:
             pebble-config: pebble-config-eab.json
           - test-name: acme_eab
             setup: 3containers
-            acme-ca: pebble 
+            acme-ca: pebble
             pebble-config: pebble-config-eab.json
           - test-name: ocsp_must_staple
             setup: 2containers
@@ -150,7 +150,7 @@ jobs:
 
       # ADD BUILT IMAGE
       - name: Download Built Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: companion.tar
 


### PR DESCRIPTION
The instability with version 4 of `actions/upload-artifact` and `actions/download-artifact` should be fixed by now.