### PR TITLE
test: upgrade pebble to 2.5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,7 @@ jobs:
             permissions_custom,
             symlinks,
             acme_hooks,
+            ocsp_must_staple,
           ]
         setup: [2containers, 3containers]
         acme-ca: [pebble]
@@ -110,12 +111,6 @@ jobs:
             setup: 3containers
             acme-ca: pebble
             pebble-config: pebble-config-eab.json
-          - test-name: ocsp_must_staple
-            setup: 2containers
-            acme-ca: boulder
-          - test-name: ocsp_must_staple
-            setup: 3containers
-            acme-ca: boulder
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
       - "*.md"
 
 env:
+  ACME_CA: pebble
   DOCKER_GEN_CONTAINER_NAME: nginx-proxy-gen
   IMAGE: nginxproxy/acme-companion
   NGINX_CONTAINER_NAME: nginx-proxy
@@ -100,16 +101,13 @@ jobs:
             ocsp_must_staple,
           ]
         setup: [2containers, 3containers]
-        acme-ca: [pebble]
         pebble-config: [pebble-config.json]
         include:
           - test-name: acme_eab
             setup: 2containers
-            acme-ca: pebble
             pebble-config: pebble-config-eab.json
           - test-name: acme_eab
             setup: 3containers
-            acme-ca: pebble
             pebble-config: pebble-config-eab.json
     runs-on: ubuntu-latest
 
@@ -128,19 +126,13 @@ jobs:
           done
 
       - name: Setup Pebble
-        if: ${{ matrix.acme-ca == 'pebble' }}
         env:
           PEBBLE_CONFIG: ${{ matrix.pebble-config }}
         run: test/setup/pebble/setup-pebble.sh
 
-      - name: Setup Boulder
-        if: ${{ matrix.acme-ca == 'boulder' }}
-        run: test/setup/setup-boulder.sh
-
       - name: Setup nginx-proxy
         env:
           SETUP: ${{ matrix.setup }}
-          ACME_CA: ${{ matrix.acme-ca }}
         run: test/setup/setup-nginx-proxy.sh
 
       # ADD BUILT IMAGE
@@ -156,7 +148,6 @@ jobs:
       - name: Integration Testing
         env:
           SETUP: ${{ matrix.setup }}
-          ACME_CA: ${{ matrix.acme-ca }}
           PEBBLE_CONFIG: ${{ matrix.pebble-config }}
         run: test/run.sh -t ${{ matrix.test-name }} "$IMAGE"
 
@@ -164,5 +155,4 @@ jobs:
         if: ${{ failure() }}
         env:
           SETUP: ${{ matrix.setup }}
-          ACME_CA: ${{ matrix.acme-ca }}
         run: test/github_actions/containers-logs.sh

--- a/test/config.sh
+++ b/test/config.sh
@@ -18,18 +18,12 @@ globalTests+=(
 	permissions_custom
 	symlinks
 	acme_hooks
+	ocsp_must_staple
 )
 
 # The acme_eab test requires Pebble with a specific configuration
 if [[ "$ACME_CA" == 'pebble' && "$PEBBLE_CONFIG" == 'pebble-config-eab.json' ]]; then
 	globalTests+=(
 		acme_eab
-	)
-fi
-
-# The ocsp_must_staple test does not work with Pebble
-if [[ "$ACME_CA" == 'boulder' ]]; then
-	globalTests+=(
-		ocsp_must_staple
 	)
 fi

--- a/test/setup/pebble/.env
+++ b/test/setup/pebble/.env
@@ -1,2 +1,2 @@
-PEBBLE_VERSION='v2.3.1'
+PEBBLE_VERSION='2.5.1'
 PEBBLE_CONFIG='pebble-config.json'

--- a/test/setup/pebble/.env
+++ b/test/setup/pebble/.env
@@ -1,2 +1,2 @@
-PEBBLE_VERSION='2.5.1'
+PEBBLE_VERSION='2.5.2'
 PEBBLE_CONFIG='pebble-config.json'

--- a/test/setup/pebble/docker-compose.yml
+++ b/test/setup/pebble/docker-compose.yml
@@ -1,14 +1,14 @@
-version: '3'
+version: "3"
 
 services:
   pebble:
-    image: "letsencrypt/pebble:${PEBBLE_VERSION}"
+    image: "ghcr.io/letsencrypt/pebble:${PEBBLE_VERSION}"
     container_name: pebble
     volumes:
       - "./${PEBBLE_CONFIG}:/test/config/pebble-config.json"
     environment:
       - PEBBLE_VA_NOSLEEP=1
-    command: pebble -config /test/config/pebble-config.json -dnsserver 10.30.50.3:8053
+    command: -config /test/config/pebble-config.json -dnsserver 10.30.50.3:8053
     ports:
       - 14000:14000 # HTTPS ACME API
       - 15000:15000 # HTTPS Management API
@@ -17,9 +17,9 @@ services:
         ipv4_address: 10.30.50.2
 
   challtestsrv:
-    image: "letsencrypt/pebble-challtestsrv:${PEBBLE_VERSION}"
+    image: "ghcr.io/letsencrypt/pebble-challtestsrv:${PEBBLE_VERSION}"
     container_name: challtestserv
-    command: pebble-challtestsrv -tlsalpn01 ""
+    command: -defaultIPv6 "" -defaultIPv4 10.30.50.3
     ports:
       - 8055:8055 # HTTP Management API
     networks:

--- a/test/setup/pebble/pebble-config-eab.json
+++ b/test/setup/pebble/pebble-config-eab.json
@@ -1,16 +1,21 @@
 {
-    "pebble": {
-        "listenAddress": "0.0.0.0:14000",
-        "managementListenAddress": "0.0.0.0:15000",
-        "certificate": "test/certs/localhost/cert.pem",
-        "privateKey": "test/certs/localhost/key.pem",
-        "httpPort": 80,
-        "tlsPort": 443,
-        "ocspResponderURL": "",
-        "externalAccountBindingRequired": true,
-        "externalAccountMACKeys": {
-            "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
-            "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
-        }
-    }
+  "pebble": {
+    "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
+    "certificate": "test/certs/localhost/cert.pem",
+    "privateKey": "test/certs/localhost/key.pem",
+    "httpPort": 80,
+    "tlsPort": 443,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": true,
+    "externalAccountMACKeys": {
+      "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
+      "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
+    },
+    "retryAfter": {
+      "authz": 3,
+      "order": 5
+    },
+    "certificateValidityPeriod": 157766400
+  }
 }

--- a/test/setup/pebble/pebble-config.json
+++ b/test/setup/pebble/pebble-config.json
@@ -1,12 +1,17 @@
 {
-    "pebble": {
-        "listenAddress": "0.0.0.0:14000",
-        "managementListenAddress": "0.0.0.0:15000",
-        "certificate": "test/certs/localhost/cert.pem",
-        "privateKey": "test/certs/localhost/key.pem",
-        "httpPort": 80,
-        "tlsPort": 443,
-        "ocspResponderURL": "",
-        "externalAccountBindingRequired": false
-    }
+  "pebble": {
+    "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
+    "certificate": "test/certs/localhost/cert.pem",
+    "privateKey": "test/certs/localhost/key.pem",
+    "httpPort": 80,
+    "tlsPort": 443,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": false,
+    "retryAfter": {
+      "authz": 3,
+      "order": 5
+    },
+    "certificateValidityPeriod": 157766400
+  }
 }


### PR DESCRIPTION
New versions of Pebble are available from ghcr.io only.

Version 2.5.x support OCSP stapling, removing the need to use Boulder in CI for this specific test.