### PR TITLE
test: use Pebble 2.6.0

### DIFF
--- a/test/setup/pebble/.env
+++ b/test/setup/pebble/.env
@@ -1,2 +1,2 @@
-PEBBLE_VERSION='2.5.2'
+PEBBLE_VERSION='2.6.0'
 PEBBLE_CONFIG='pebble-config.json'


### PR DESCRIPTION
Not much to see here, just bumping the Pebble version used in tests.