### PR TITLE
feat: standalone certs with LETSENCRYPT_HOST

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -141,7 +141,9 @@ function add_standalone_configuration {
     local domain="${1:?}"
     if grep -q "server_name ${domain};" /etc/nginx/conf.d/*.conf; then
         # If the domain is already present in nginx's conf, use the location configuration.
-        add_location_configuration "$domain"
+        if parse_true "${ACME_HTTP_CHALLENGE_LOCATION:=false}"; then
+            add_location_configuration "$domain"
+        fi
     else
         # Else use the standalone configuration.
         cat > "/etc/nginx/conf.d/standalone-cert-$domain.conf" << EOF

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -349,9 +349,7 @@ function update_cert {
         # Add all the domains to certificate
         params_issue_arr+=(--domain "$domain")
         # If enabled, add location configuration for the domain
-        if parse_true "${ACME_HTTP_CHALLENGE_LOCATION:=false}"; then
-            add_location_configuration "$domain" || reload_nginx
-        fi
+        add_standalone_configuration "$domain" || reload_nginx
     done
 
     params_issue_arr=("${params_base_arr[@]}" "${params_issue_arr[@]}")


### PR DESCRIPTION
This commit enables the creation of standalone certificates using the environment variable `LETSENCRYPT_HOST` without using `VIRTUAL_HOST`.

@buchdag would you be open to such an idea?