### PR TITLE
Bugfix: Standalone ACMESH_${cid}_DNS_API_CONFIG env variable is not properly formatted to be parsed correctly.

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -190,7 +190,15 @@ function update_cert {
         local default_acmesh_dns_api="${DEFAULT_ACMESH_DNS_API_CONFIG[DNS_API]}"
         [[ -n "$default_acmesh_dns_api" ]] && acmesh_dns_config_used='default'
 
-        local -n acmesh_dns_config="ACMESH_${cid}_DNS_API_CONFIG"
+        local -n acmesh_dns_config_env_var="ACMESH_${cid}_DNS_API_CONFIG"
+
+        # Fix formatting for jq (switch single quotes for double)
+        acmesh_dns_config_env_var=${acmesh_dns_config_env_var//\'/\"}
+
+        # Convert json to assoc array
+        declare -A acmesh_dns_config=$(
+            jq -r '"(",(to_entries | .[] | "["+(.key|@sh)+"]="+(.value|@sh)),")"' <<< $acmesh_dns_config_env_var
+        )
         local acmesh_dns_api="${acmesh_dns_config[DNS_API]}"
         [[ -n "$acmesh_dns_api" ]] && acmesh_dns_config_used='container'
 


### PR DESCRIPTION
The standalone ACMESH_${cid}_DNS_API_CONFIG env variable is not properly formatted when read and is unable to be properly parsed. So it always falls back to the global DEFAULT_ACMESH_DNS_API_CONFIG.

If you attempt to define a standalone DNS_API_CONFIG variable, the script will error.

```
nginx-acme-acme-companion  | [Thu Sep 26 12:55:40 UTC 2024] Domains not changed.
nginx-acme-acme-companion  | [Thu Sep 26 12:55:40 UTC 2024] Skipping. Next renewal time is: 2024-11-18T14:10:56Z
nginx-acme-acme-companion  | [Thu Sep 26 12:55:40 UTC 2024] Add '--force' to force renewal.
nginx-acme-acme-companion  | /app/letsencrypt_service: line 217: local: `0={ 'DNS_API': 'dns_cf', 'CF_Token': '<REDACTED>', 'CF_Account_ID': '<REDACTED>', 'CF_Zone_ID':'<REDACTED>'}': not a valid identifier
nginx-acme-acme-companion  | Info: DNS challenge using { 'DNS_API': 'dns_cf', 'CF_Token': '<REDACTED>', 'CF_Account_ID': '<REDACTED>', 'CF_Zone_ID':'<REDACTED>'} DNS API with the following keys: 0 (container config)
nginx-acme-acme-companion  | Creating/renewal <REDACTED.DOMAIN.COM> certificates... (<REDACTED.DOMAIN.COM>)
```

This prevents you from having multiple standalone domains that require different API settings for DNS-01. i.e one domain using Cloudflare and another using Dreamhost, for example. 

This change will properly format the environment variable into an assoc array once it is read in and you can now successfully apply multiple DNS_API_CONFIG settings in standalone config.

