### PR TITLE
Docs: Clarify standalone dns01 API configuration structure with example

### DIFF
--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -61,7 +61,7 @@ LETSENCRYPT_web_HOST=('yourdomain.tld' 'www.yourdomain.tld')
 LETSENCRYPT_app_HOST=('myapp.yourdomain.tld' 'myapp.yourotherdomain.tld' 'service.yourotherdomain.tld')
 LETSENCRYPT_othersite_HOST=('yetanotherdomain.tld')
 
-ACMESH_othersite_DNS_API_CONFIG
+ACME_othersite_CHALLENGE=DNS-01
 declare -A ACMESH_othersite_DNS_API_CONFIG=(
     ['DNS_API']='dns_cf'
     ['CF_Token']='<CLOUDFLARE_TOKEN>'

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -52,7 +52,8 @@ LETSENCRYPT_othersite_HOST=('yetanotherdomain.tld')
 ```
 
 **Example using DNS-01 verification:**
-In this `web` and `app` generate a vertificate using the default configuration (HTTP-01). But `othersite` will perform it's certificate generation using DNS-01.
+
+In this example: `web` and `app` generate a certificate using the global/default configuration. However `othersite` will perform it's certificate verification using a specific DNS-01 API configuration.
 
 ```bash
 LETSENCRYPT_STANDALONE_CERTS=('web' 'app' 'othersite')

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -51,6 +51,24 @@ LETSENCRYPT_app_HOST=('myapp.yourdomain.tld' 'myapp.yourotherdomain.tld' 'servic
 LETSENCRYPT_othersite_HOST=('yetanotherdomain.tld')
 ```
 
+**Example using DNS-01 verification:**
+In this `web` and `app` generate a vertificate using the default configuration (HTTP-01). But `othersite` will perform it's certificate generation using DNS-01.
+
+```bash
+LETSENCRYPT_STANDALONE_CERTS=('web' 'app' 'othersite')
+LETSENCRYPT_web_HOST=('yourdomain.tld' 'www.yourdomain.tld')
+LETSENCRYPT_app_HOST=('myapp.yourdomain.tld' 'myapp.yourotherdomain.tld' 'service.yourotherdomain.tld')
+LETSENCRYPT_othersite_HOST=('yetanotherdomain.tld')
+
+ACMESH_othersite_DNS_API_CONFIG
+declare -A ACMESH_othersite_DNS_API_CONFIG=(
+    ['DNS_API']='dns_cf'
+    ['CF_Token']='<CLOUDFLARE_TOKEN>'
+    ['CF_Account_ID']='<CLOUDFLARE_ACCOUNT_ID>'
+    ['CF_Zone_ID']='<CLOUDFLARE_ZONE_ID>'
+)
+```
+
 ### Optional configuration parameters:
 
 Single bash variables:
@@ -61,14 +79,14 @@ Single bash variables:
 
 `LETSENCRYPT_uniqueidentifier_TEST` : if set to true, the corresponding certificate will be a test certificates: it won't have the 5 certs/week/domain limits and will be signed by an untrusted intermediate (ie it won't be trusted by browsers).
 
-`ACME_uniqueidentifier_CHALLENGE`: Defaults to HTTP-01. In order to switch to the DNS-01 ACME challenge set it to `DNS-01`
+Using DNS-01 on standalone certtificates:
 
-More advanced types:
+`ACME_uniqueidentifier_CHALLENGE`: Defaults to HTTP-01. In order to switch to the DNS-01 ACME challenge set it to `DNS-01`
 
 `ACMESH_uniqueidentifier_DNS_API_CONFIG`: Defaults to the values of DNS_API_CONFIG. However if you wish to specify a specific DNS-01 verification method on a particular standalone certificate. It must be defined as a bash associative array.
 
 Example
-```
+```bash
 declare -A ACMESH_alt_DNS_API_CONFIG=(
     ['DNS_API']='dns_cf'
     ['CF_Token']='<CLOUDFLARE_TOKEN>'

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -80,7 +80,7 @@ Single bash variables:
 
 `LETSENCRYPT_uniqueidentifier_TEST` : if set to true, the corresponding certificate will be a test certificates: it won't have the 5 certs/week/domain limits and will be signed by an untrusted intermediate (ie it won't be trusted by browsers).
 
-Using DNS-01 on standalone certificates:
+DNS-01 related variables:
 
 `ACME_uniqueidentifier_CHALLENGE`: Defaults to HTTP-01. In order to switch to the DNS-01 ACME challenge set it to `DNS-01`
 

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -53,13 +53,29 @@ LETSENCRYPT_othersite_HOST=('yetanotherdomain.tld')
 
 ### Optional configuration parameters:
 
-Those are all single bash variables.
+Single bash variables:
 
 `LETSENCRYPT_uniqueidentifier_EMAIL` : must be a valid email and will be used by Let's Encrypt to warn you of impeding certificate expiration (should the automated renewal fail).
 
 `LETSENCRYPT_uniqueidentifier_KEYSIZE` : determines the size of the requested private key. See [private key size](./Let's-Encrypt-and-ACME.md#private-key-size) for accepted values.
 
 `LETSENCRYPT_uniqueidentifier_TEST` : if set to true, the corresponding certificate will be a test certificates: it won't have the 5 certs/week/domain limits and will be signed by an untrusted intermediate (ie it won't be trusted by browsers).
+
+`ACME_uniqueidentifier_CHALLENGE`: Defaults to HTTP-01. In order to switch to the DNS-01 ACME challenge set it to `DNS-01`
+
+More advanced types:
+
+`ACMESH_uniqueidentifier_DNS_API_CONFIG`: Defaults to the values of DNS_API_CONFIG. However if you wish to specify a specific DNS-01 verification method on a particular standalone certificate. It must be defined as a bash associative array.
+
+Example
+```
+declare -A ACMESH_alt_DNS_API_CONFIG=(
+    ['DNS_API']='dns_cf'
+    ['CF_Token']='<CLOUDFLARE_TOKEN>'
+    ['CF_Account_ID']='<CLOUDFLARE_ACCOUNT_ID>'
+    ['CF_Zone_ID']='<CLOUDFLARE_ZONE_ID>'
+)
+```
 
 ### Picking up changes to letsencrypt_user_data
 

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -80,7 +80,7 @@ Single bash variables:
 
 `LETSENCRYPT_uniqueidentifier_TEST` : if set to true, the corresponding certificate will be a test certificates: it won't have the 5 certs/week/domain limits and will be signed by an untrusted intermediate (ie it won't be trusted by browsers).
 
-Using DNS-01 on standalone certtificates:
+Using DNS-01 on standalone certificates:
 
 `ACME_uniqueidentifier_CHALLENGE`: Defaults to HTTP-01. In order to switch to the DNS-01 ACME challenge set it to `DNS-01`
 


### PR DESCRIPTION
As discussed. Added a little more detail into the standalone configuration doc to be more specific around what is required when defining a specific DNS API configuration for a standalone cert.