### PR TITLE
docs: update Basic-usage.md

### DIFF
--- a/docs/Basic-usage.md
+++ b/docs/Basic-usage.md
@@ -37,6 +37,7 @@ $ docker run --detach \
     --name nginx-proxy-acme \
     --volumes-from nginx-proxy \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
+    --volume certs:/etc/nginx/certs:rw \
     --volume acme:/etc/acme.sh \
     --env "DEFAULT_EMAIL=mail@yourdomain.tld" \
     nginxproxy/acme-companion


### PR DESCRIPTION
There is a difference between docker compose example and docker run for the acme-companion service about the certificat volume.

https://github.com/nginx-proxy/acme-companion/blob/main/docs/Docker-Compose.md?plain=1#L45

I imagine that the docker compose is the right syntax