### PR TITLE
docs: specify correct amount of volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ In addition to the above, please ensure that your DNS provider answers correctly
 
 ## Basic usage (with the nginx-proxy container)
 
-Three writable volumes must be declared on the **nginx-proxy** container so that they can be shared with the **acme-companion** container:
+Two writable volumes must be declared on the **nginx-proxy** container so that they can be shared with the **acme-companion** container:
 
 * `/etc/nginx/certs` to store certificates and private keys (readonly for the **nginx-proxy** container).
 * `/usr/share/nginx/html` to write `http-01` challenge files.
 
-Additionally, a fourth volume must be declared on the **acme-companion** container to store `acme.sh` configuration and state: `/etc/acme.sh`.
+Additionally, a third volume must be declared on the **acme-companion** container to store `acme.sh` configuration and state: `/etc/acme.sh`.
 
 Please also read the doc about [data persistence](./docs/Persistent-data.md).
 
@@ -45,7 +45,7 @@ Example of use:
 
 ### Step 1 - nginx-proxy
 
-Start **nginx-proxy** with the three additional volumes declared:
+Start **nginx-proxy** with the two additional volumes declared:
 
 ```shell
 $ docker run --detach \

--- a/docs/Basic-usage.md
+++ b/docs/Basic-usage.md
@@ -5,7 +5,7 @@ Two writable volumes must be declared on the **nginx-proxy** container so that t
 * `/etc/nginx/certs` to store certificates and private keys (readonly for the **nginx-proxy** container).
 * `/usr/share/nginx/html` to write `HTTP-01` challenge files.
 
-Additionally, a fourth volume must be declared on the **acme-companion** container to store `acme.sh` configuration and state: `/etc/acme.sh`.
+Additionally, a third volume must be declared on the **acme-companion** container to store `acme.sh` configuration and state: `/etc/acme.sh`.
 
 Please also read the doc about [data persistence](./Persistent-data.md).
 
@@ -13,7 +13,7 @@ Example of use:
 
 ### Step 1 - nginx-proxy
 
-Start **nginx-proxy** with the three additional volumes declared:
+Start **nginx-proxy** with the two additional volumes declared:
 
 ```shell
 $ docker run --detach \


### PR DESCRIPTION
I'm in the middle of setting this up and was a bit confused by the README.md being a bit ambiguous about volume count. In some places it refers to there being three required volumes, but the subsequent example shows only two.

I found this commit [28bdc6b8](https://github.com/nginx-proxy/acme-companion/commit/28bdc6b8322d8b199e47aa5a34b345ad65182d71) that removes the third volume and changes the language to refer to _two volumes_.

My conclusion is: there should be two volumes and there's been an editing mistake. This MR is just to fix the forgotten references to three volumes. _I did NOT try to understand how anything works or WHY there is only two now._

((I don't think i've made an MR like this before. Should i have made an issue first?))