### PR TITLE
fix: reverse docker socket test

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -14,14 +14,14 @@ function print_version {
 function check_docker_socket {
     if [[ $DOCKER_HOST == unix://* ]]; then
         socket_file=${DOCKER_HOST#unix://}
-	if [[ ! -S $socket_file ]]; then
+        if [[ ! -S $socket_file ]]; then
+            if [[ ! -r $socket_file ]]; then
+                echo "Warning: Docker host socket at $socket_file might not be readable. Please check user permissions" >&2
+                echo "If you are in a SELinux environment, try using: '-v /var/run/docker.sock:$socket_file:z'" >&2
+            fi
             echo "Error: you need to share your Docker host socket with a volume at $socket_file" >&2
             echo "Typically you should run your container with: '-v /var/run/docker.sock:$socket_file:ro'" >&2
             exit 1
-        fi
-        if [[ ! -r $socket_file ]]; then
-            echo "Warning: Docker host socket at $socket_file might not be readable. Please check user permissions" >&2
-            echo "If you are in a SELinux environment, try using: '-v /var/run/docker.sock:$socket_file:z'" >&2
         fi
     fi
 }

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -14,15 +14,14 @@ function print_version {
 function check_docker_socket {
     if [[ $DOCKER_HOST == unix://* ]]; then
         socket_file=${DOCKER_HOST#unix://}
-	if [[ ! -r $socket_file ]]; then
-            echo "Error: Docker host socket at $socket_file is not readable. Please check user permissions" >&2
-            echo "If you are in a SELinux environment, try using: '-v /var/run/docker.sock:$socket_file:z'" >&2
-            exit 1
-        fi
-        if [[ ! -S $socket_file ]]; then
+	    if [[ ! -S $socket_file ]]; then
             echo "Error: you need to share your Docker host socket with a volume at $socket_file" >&2
             echo "Typically you should run your container with: '-v /var/run/docker.sock:$socket_file:ro'" >&2
             exit 1
+        fi
+        if [[ ! -r $socket_file ]]; then
+            echo "Warning: Docker host socket at $socket_file might not be readable. Please check user permissions" >&2
+            echo "If you are in a SELinux environment, try using: '-v /var/run/docker.sock:$socket_file:z'" >&2
         fi
     fi
 }

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -14,7 +14,7 @@ function print_version {
 function check_docker_socket {
     if [[ $DOCKER_HOST == unix://* ]]; then
         socket_file=${DOCKER_HOST#unix://}
-	    if [[ ! -S $socket_file ]]; then
+	if [[ ! -S $socket_file ]]; then
             echo "Error: you need to share your Docker host socket with a volume at $socket_file" >&2
             echo "Typically you should run your container with: '-v /var/run/docker.sock:$socket_file:ro'" >&2
             exit 1


### PR DESCRIPTION
Fix proposed by @andrei-datcu for #1179 

The entrypoint will fail if `test -S $socket_file` is `false` but only display a warning if `test -r $socket_file` is `false`.