### PR TITLE
build: add `syntax` parser directive to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM docker.io/nginxproxy/docker-gen:0.14.5 AS docker-gen
 
 FROM docker.io/library/alpine:3.21.3


### PR DESCRIPTION
## What?

Add [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to the first line of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).

## Why?

To declare the Dockerfile syntax version to use for the build.
If unspecified, [BuildKit](https://docs.docker.com/build/buildkit/) uses a bundled version of the Dockerfile frontend.

## How?

Append `# syntax=docker.io/docker/dockerfile:1` to the top of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).