### PR TITLE
Fix doc: add html volume to acme-companion service

### DIFF
--- a/docs/Docker-Compose.md
+++ b/docs/Docker-Compose.md
@@ -41,6 +41,7 @@ services:
     volumes:
       - certs:/etc/nginx/certs:rw
       - acme:/etc/acme.sh
+      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
 #networks:
@@ -95,6 +96,7 @@ services:
     volumes:
       - certs:/etc/nginx/certs:rw
       - acme:/etc/acme.sh
+      - html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
 #networks:


### PR DESCRIPTION
The acme-companion service needs access to the HTML volume where the Let's Encrypt validation file (.well-known/acme-challenge/...) is located.