### PR TITLE
feat: parameterize nginx-proxy and docker-gen container labels

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -181,14 +181,16 @@ if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
         echo "Error: can't get nginx-proxy container ID !" >&2
         echo "Check that you are doing one of the following :" >&2
         echo -e "\t- Use the --volumes-from option to mount volumes from the nginx-proxy container." >&2
-        echo -e "\t- Set the NGINX_PROXY_CONTAINER env var on the letsencrypt-companion container to the name of the nginx-proxy container." >&2
-        echo -e "\t- Label the nginx-proxy container to use with 'com.github.nginx-proxy.nginx'." >&2
+        echo -e "\t- Set the NGINX_PROXY_CONTAINER env var on the acme-companion container to the name of the nginx-proxy container." >&2
+        echo -e "\t- Label the nginx-proxy container to use with '${default_nginx_proxy_container_label}'." >&2
+        echo -e "\t- Label the nginx-proxy container with a custom label and set NGINX_PROXY_CONTAINER_LABEL env var on the acme-companion container to match the custom label." >&2
         exit 1
     elif [[ -z "$(get_docker_gen_container)" ]] && ! is_docker_gen_container "$(get_nginx_proxy_container)"; then
         echo "Error: can't get docker-gen container id !" >&2
         echo "If you are running a three containers setup, check that you are doing one of the following :" >&2
-        echo -e "\t- Set the NGINX_DOCKER_GEN_CONTAINER env var on the letsencrypt-companion container to the name of the docker-gen container." >&2
-        echo -e "\t- Label the docker-gen container to use with 'com.github.nginx-proxy.docker-gen'." >&2
+        echo -e "\t- Set the NGINX_DOCKER_GEN_CONTAINER env var on the acme-companion container to the name of the docker-gen container." >&2
+        echo -e "\t- Label the docker-gen container to use with '${default_nginx_docker_gen_container_label}'." >&2
+        echo -e "\t- Label the docker-gen container with a custom label and set NGINX_DOCKER_GEN_CONTAINER_LABEL env var on the acme-companion container to match the custom label." >&2
         exit 1
     fi
     check_writable_directory '/etc/nginx/certs'

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -10,6 +10,11 @@ if [[ "$DEBUG" == true ]]; then
   DEBUG=1 && export DEBUG
 fi
 
+default_nginx_docker_gen_container_label=com.github.nginx-proxy.docker-gen
+default_nginx_proxy_container_label=com.github.nginx-proxy.nginx
+runtime_nginx_docker_gen_container_label=${NGINX_DOCKER_GEN_CONTAINER_LABEL:-$default_nginx_docker_gen_container_label}
+runtime_nginx_proxy_container_label=${NGINX_PROXY_CONTAINER_LABEL:-$default_nginx_proxy_container_label}
+
 function parse_true() {
 	case "$1" in
 
@@ -284,7 +289,7 @@ function is_docker_gen_container {
 function get_docker_gen_container {
     # First try to get the docker-gen container ID from the container label.
     local legacy_docker_gen_cid; legacy_docker_gen_cid="$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.docker_gen)"
-    local new_docker_gen_cid; new_docker_gen_cid="$(labeled_cid com.github.nginx-proxy.docker-gen)"
+    local new_docker_gen_cid; new_docker_gen_cid="$(labeled_cid $runtime_nginx_docker_gen_container_label)"
     local docker_gen_cid; docker_gen_cid="${new_docker_gen_cid:-$legacy_docker_gen_cid}"
 
     # If the labeled_cid function dit not return anything and the env var is set, use it.
@@ -300,7 +305,7 @@ function get_nginx_proxy_container {
     local volumes_from
     # First try to get the nginx container ID from the container label.
     local legacy_nginx_cid; legacy_nginx_cid="$(labeled_cid com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy)"
-    local new_nginx_cid; new_nginx_cid="$(labeled_cid com.github.nginx-proxy.nginx)"
+    local new_nginx_cid; new_nginx_cid="$(labeled_cid $runtime_nginx_proxy_container_label)"
     local nginx_cid; nginx_cid="${new_nginx_cid:-$legacy_nginx_cid}"
 
     # If the labeled_cid function dit not return anything ...

--- a/docs/Getting-containers-IDs.md
+++ b/docs/Getting-containers-IDs.md
@@ -6,6 +6,8 @@ There are three methods to inform the **acme-companion** container of the **ngin
 
 * `label` method: add the label `com.github.nginx-proxy.nginx` to the **nginx**/**nginx-proxy** container.
 
+  * Optional. Using a custom `label`: add a custom label, e.g. :`custom.label.nginx` to the **nginx**/**nginx-proxy** container and set the environment variable `NGINX_PROXY_CONTAINER_LABEL` to match the custom label.
+
 * `environment variable` method: assign a fixed name to the **nginx**/**nginx-proxy** container with `container_name:` and set the environment variable `NGINX_PROXY_CONTAINER` to this name on the **acme-companion** container.
 
 * `volumes_from` method. Using this method, the **acme-companion** container will get the **nginx**/**nginx-proxy** container ID from the volumes it got using the `volumes_from` option.
@@ -13,6 +15,8 @@ There are three methods to inform the **acme-companion** container of the **ngin
 And two methods to inform the **acme-companion** container of the **docker-gen** container ID:
 
 * `label` method: add the label `com.github.nginx-proxy.docker-gen` to the **docker-gen** container.
+
+  * Optional. Using a custom `label`: add a custom label, e.g. :`custom.label.docker-gen` to the **docker-gen** container and set the environment variable `NGINX_DOCKER_GEN_CONTAINER_LABEL` to match the custom label.
 
 * `environment variable` method: assign a fixed name to the **docker-gen** container with `container_name:` and set the environment variable `NGINX_DOCKER_GEN_CONTAINER` to this name on the **acme-companion** container.
 
@@ -36,6 +40,25 @@ $ docker run --detach \
 
 $ docker run --detach \
     [...]
+    nginxproxy/acme-companion
+```
+
+`label` method with custom label.
+```
+$ docker run --detach \
+    [...]
+    --label custom.label.nginx \
+    nginx
+
+$ docker run --detach \
+    [...]
+    --label custom.label.docker-gen \
+    nginxproxy/docker-gen
+
+$ docker run --detach \
+    [...]
+    --env NGINX_PROXY_CONTAINER_LABEL=custom.label.nginx
+    --env NGINX_DOCKER_GEN_CONTAINER_LABEL=custom.label.docker-gen
     nginxproxy/acme-companion
 ```
 


### PR DESCRIPTION
This change enable users to be able to change the default label acme-companion uses to lookup for nginx and docker-gen containers, allowing more personalization to further uses of acme-companion.

As an example, nginx-proxy/nginx-proxy project now defines it's nginx-proxy label as `com.github.nginx-proxy.nginx-proxy.nginx`, instead of adding an exception to the case to handle current nginx-proxy label `com.github.nginx-proxy.nginx` as a secondary legacy label, it provides a way to pass custom container labels through the parameterization of the current container labels.