### PR TITLE
feat: per-container certificate renewal timing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,8 @@ jobs:
             certs_san,
             certs_single_domain,
             certs_standalone,
+            certs_renew_after,
+            certs_default_renew_deprecated,
             cert_profiles,
             force_renew,
             acme_accounts,

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -174,6 +174,14 @@ function check_default_account {
     fi
 }
 
+function check_renew_after_env {
+    # Check for deprecated DEFAULT_RENEW variable
+    if [[ -n "${DEFAULT_RENEW:-}" && -z "${ACME_RENEW_AFTER:-}" ]]; then
+        echo "Warning: DEFAULT_RENEW is deprecated. Please use ACME_RENEW_AFTER instead." >&2
+        export ACME_RENEW_AFTER="$DEFAULT_RENEW"
+    fi
+}
+
 if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     print_version
     check_docker_socket
@@ -203,6 +211,7 @@ if [[ "$*" == "/bin/bash /app/start.sh" ]]; then
     check_dh_group
     reload_nginx
     check_default_account
+    check_renew_after_env
 fi
 
 exec "$@"

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -8,7 +8,7 @@ ACME_CA_URI="${ACME_CA_URI:-"https://acme-v02.api.letsencrypt.org/directory"}"
 ACME_CA_TEST_URI="https://acme-staging-v02.api.letsencrypt.org/directory"
 DEFAULT_KEY_SIZE="${DEFAULT_KEY_SIZE:-4096}"
 RENEW_PRIVATE_KEYS="$(lc "${RENEW_PRIVATE_KEYS:-true}")"
-DEFAULT_RENEW="${DEFAULT_RENEW:-60}"
+ACME_RENEW_AFTER="${ACME_RENEW_AFTER:-60}"
 
 # Backward compatibility environment variable
 REUSE_PRIVATE_KEYS="$(lc "${REUSE_PRIVATE_KEYS:-false}")"
@@ -456,8 +456,12 @@ function update_cert {
         fi
     done
 
-    # Allow to override day to renew cert
-    params_issue_arr+=(--days "$DEFAULT_RENEW")
+    # Allow to override day to renew cert (per-container or global)
+    local -n renew_after="ACME_${cid}_RENEW_AFTER"
+    if [[ -z "$renew_after" ]] || [[ ! "$renew_after" =~ ^[0-9]+$ ]]; then
+        renew_after="$ACME_RENEW_AFTER"
+    fi
+    params_issue_arr+=(--days "$renew_after")
 
     params_issue_arr=("${params_base_arr[@]}" "${params_issue_arr[@]}")
     [[ "$DEBUG" == 1 ]] && echo "Calling acme.sh --issue with the following parameters : ${params_issue_arr[*]}"

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -47,6 +47,7 @@ LETSENCRYPT_CONTAINERS=(
         {{ $RESTART_CONTAINER := trim (coalesce $container.Env.LETSENCRYPT_RESTART_CONTAINER "") }}
         {{ $PRE_HOOK := trim (coalesce $container.Env.ACME_PRE_HOOK "") }}
         {{ $POST_HOOK := trim (coalesce $container.Env.ACME_POST_HOOK "") }}
+        {{ $RENEW_AFTER := trim (coalesce $container.Env.ACME_RENEW_AFTER "") }}
         {{ $cid := printf "%.12s" $container.ID }}
         {{- "\n" }}# Container {{ $cid }} ({{ $container.Name }})
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
@@ -77,6 +78,7 @@ LETSENCRYPT_CONTAINERS=(
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_PRE_HOOK="{{ $PRE_HOOK }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_POST_HOOK="{{ $POST_HOOK }}"
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_RENEW_AFTER="{{ $RENEW_AFTER }}"
             {{ end }}
         {{ else }}
             {{/* Default: multi-domain (SAN) certificate */}}
@@ -108,6 +110,7 @@ LETSENCRYPT_CONTAINERS=(
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_RESTART_CONTAINER="{{ $RESTART_CONTAINER }}"
             {{- "\n" }}ACME_{{ $cid }}_PRE_HOOK="{{ $PRE_HOOK }}"
             {{- "\n" }}ACME_{{ $cid }}_POST_HOOK="{{ $POST_HOOK }}"
+            {{- "\n" }}ACME_{{ $cid }}_RENEW_AFTER="{{ $RENEW_AFTER }}"
         {{ end }}
     {{ end }}
 {{ end }}

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -34,7 +34,9 @@ You can also create test certificates per container (see [Test certificates](./L
 
 * `ACME_POST_HOOK` - The provided command will be run after every certificate issuance. The action is limited to the commands available inside the **acme-companion** container. For example `--env "ACME_POST_HOOK=echo 'end'"`. For more information see [Pre- and Post-Hook](./Hooks.md)
 
-* `DEFAULT_RENEW` - 60 days by default, this defines the number of days between certificate renewals attempts. For certificates issued by certain Certificate Authorities, such as Buypass, which have a lifespan of 180 days, it may be advisable to initiate the renewal process on day 170 rather than the default day 60. See [BuyPass.com CA](https://github.com/acmesh-official/acme.sh/wiki/BuyPass.com-CA) for more detail.
+* `ACME_RENEW_AFTER` - 60 days by default, this defines the number of days between certificate renewals attempts. For certificates issued by certain Certificate Authorities, such as Buypass, which have a lifespan of 180 days, it may be advisable to initiate the renewal process on day 150 rather than the default day 60. See [BuyPass.com CA](https://github.com/acmesh-official/acme.sh/wiki/BuyPass.com-CA) for more detail. This can also be set per-container (see [Certificate renewal timing](./Let's-Encrypt-and-ACME.md#certificate-renewal-timing)).
+
+* `DEFAULT_RENEW` - **DEPRECATED**: This variable is deprecated and replaced by `ACME_RENEW_AFTER`. It still works for backward compatibility, but a warning will be logged on container startup. Please migrate to `ACME_RENEW_AFTER`.
 
 * `ACME_HTTP_CHALLENGE_LOCATION` - Previously **acme-companion** automatically added the ACME HTTP challenge location to the nginx configuration through files generated in `/etc/nginx/vhost.d`. Recent versions of **nginx-proxy** (>= `1.6`) already include the required location configuration, which remove the need for **acme-companion** to attempt to dynamically add them. If you're running and older version of **nginx-proxy** (or **docker-gen** with an older version of the `nginx.tmpl` file), you can re-enable this behaviour by setting `ACME_HTTP_CHALLENGE_LOCATION` to `true`.
 

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -125,7 +125,7 @@ If the ACME CA provides multiple cert chain, you can use the `ACME_PREFERRED_CHA
 
 #### Certificate profile
 
-The `ACME_CERT_PROFILE` environment variable is used to select a specific profile offered by the CA. See for example [the list of profiles offered by Letsencrypt](https://letsencrypt.org/docs/profiles). Note that some profiles might reduce the validity period of the certificate; you might need to adjust the (global) `DEFAULT_RENEW` variable to make sure it gets updated in time.
+The `ACME_CERT_PROFILE` environment variable is used to select a specific profile offered by the CA. See for example [the list of profiles offered by Letsencrypt](https://letsencrypt.org/docs/profiles). Note that some profiles might reduce the validity period of the certificate; you might need to adjust the (global) `ACME_RENEW_AFTER` variable or set it per-container to make sure it gets updated in time.
 
 #### Container restart on cert renewal
 
@@ -134,6 +134,10 @@ The `LETSENCRYPT_RESTART_CONTAINER` environment variable, when set to `true` on 
 #### Pre-Hook and Post-Hook
 
 The `ACME_PRE_HOOK` and `ACME_POST_HOOK` let you use the [`acme.sh` Pre- and Post-Hooks feature](https://github.com/acmesh-official/acme.sh/wiki/Using-pre-hook-post-hook-renew-hook-reloadcmd) to run commands respectively before and after the container's certificate has been issued. For more information see [Pre- and Post-Hook](./Hooks.md)
+
+#### Certificate renewal timing
+
+The `ACME_RENEW_AFTER` environment variable can be set on an application container to override the global renewal timing for that specific container's certificate. This is useful for certificates from CAs with different validity periods. For example, Buypass certificates have a 180-day lifespan, so you might want to set `ACME_RENEW_AFTER=150` on those containers while keeping the default 60 days for Let's Encrypt certificates on others.
 
 
 ### global (set on acme-companion container)

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -137,7 +137,7 @@ The `ACME_PRE_HOOK` and `ACME_POST_HOOK` let you use the [`acme.sh` Pre- and Pos
 
 #### Certificate renewal timing
 
-The `ACME_RENEW_AFTER` environment variable can be set on an application container to override the global renewal timing for that specific container's certificate. This is useful for certificates from CAs with different validity periods. For example, Buypass certificates have a 180-day lifespan, so you might want to set `ACME_RENEW_AFTER=150` on those containers while keeping the default 60 days for Let's Encrypt certificates on others.
+The `ACME_RENEW_AFTER` environment variable can be set on an application container to override the global renewal timing for that specific container's certificate. This is useful when using a CA or a [certificate profile](#certificate-profile) with a different validity period; for example, Buypass certificates have a lifespan of 180 days, and Let's Encrypt's offers [`tlsserver`](https://letsencrypt.org/docs/profiles/#tlsserver) (45 days) and [`shortlived`](https://letsencrypt.org/docs/profiles/#shortlived)  (180 hours) profiles. For example, Buypass certificates have a 180-day lifespan, so you might want to set `ACME_RENEW_AFTER=150` on those containers while keeping the default 60 days for Let's Encrypt certificates on others.
 
 
 ### global (set on acme-companion container)

--- a/test/config.sh
+++ b/test/config.sh
@@ -17,7 +17,8 @@ globalTests+=(
 	permissions_custom
 	symlinks
 	acme_hooks
-	certs_default_renew
+	certs_renew_after
+	certs_default_renew_deprecated
 	ocsp_must_staple
 )
 

--- a/test/tests/certs_default_renew_deprecated/run.sh
+++ b/test/tests/certs_default_renew_deprecated/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Test for the DEFAULT_RENEW function.
+## Test for backward compatibility with deprecated DEFAULT_RENEW.
 
 if [[ -z $GITHUB_ACTIONS ]]; then
   le_container_name="$(basename "${0%/*}")_$(date "+%Y-%m-%d_%H.%M.%S")"
@@ -26,6 +26,20 @@ function cleanup {
 }
 trap cleanup EXIT
 
+# Check for deprecation warning in container logs
+deprecation_warning_found=false
+for _ in {1..10}; do
+  if docker logs "$le_container_name" 2>&1 | grep -q "Warning: DEFAULT_RENEW is deprecated. Please use ACME_RENEW_AFTER instead."; then
+    deprecation_warning_found=true
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$deprecation_warning_found" != true ]]; then
+  echo "Deprecation warning not found in container logs"
+fi
+
 container_email="contact@${domains[0]}"
 acme_config_file="/etc/acme.sh/$container_email/${domains[0]}/${domains[0]}.conf"
 
@@ -40,8 +54,8 @@ acme_cert_create_time_key="Le_CertCreateTime="
 acme_renewal_days_key="Le_RenewalDays="
 acme_next_renew_time_key="Le_NextRenewTime="
 
-# Check if the default command is deliverd properly in /etc/acme.sh
-if docker exec "$le_container_name" [[ ! -f "$acme_config_file" ]]; then
+# Check if the default command is delivered properly in /etc/acme.sh
+if ! docker exec "$le_container_name" test -f "$acme_config_file"; then
   echo "The $acme_config_file file does not exist."
 fi
 

--- a/test/tests/certs_renew_after/run.sh
+++ b/test/tests/certs_renew_after/run.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+## Test for the ACME_RENEW_AFTER function.
+
+if [[ -z $GITHUB_ACTIONS ]]; then
+  le_container_name="$(basename "${0%/*}")_$(date "+%Y-%m-%d_%H.%M.%S")"
+else
+  le_container_name="$(basename "${0%/*}")"
+fi
+
+global_renew=170
+run_le_container "${1:?}" "$le_container_name" \
+  --cli-args "--env ACME_RENEW_AFTER=$global_renew"
+
+# Create the $domains array from comma separated domains in TEST_DOMAINS.
+IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
+
+# Cleanup function with EXIT trap
+function cleanup {
+  # Remove any remaining Nginx container(s) silently.
+  docker rm --force "${domains[0]}" "${domains[1]}" &> /dev/null
+  # Cleanup the files created by this run of the test to avoid foiling following test(s).
+  docker exec "$le_container_name" /app/cleanup_test_artifacts
+  # Stop the LE container
+  docker stop "$le_container_name" > /dev/null
+}
+trap cleanup EXIT
+
+acme_cert_create_time_key="Le_CertCreateTime="
+acme_renewal_days_key="Le_RenewalDays="
+acme_next_renew_time_key="Le_NextRenewTime="
+
+# Test global ACME_RENEW_AFTER setting
+container_email="contact@${domains[0]}"
+acme_config_file="/etc/acme.sh/$container_email/${domains[0]}/${domains[0]}.conf"
+
+# Run a nginx container for ${domains[0]} with LETSENCRYPT_EMAIL set.
+run_nginx_container --hosts "${domains[0]}" \
+  --cli-args "--env LETSENCRYPT_EMAIL=${container_email}"
+
+# Wait for a symlink at /etc/nginx/certs/${domains[0]}.crt
+wait_for_symlink "${domains[0]}" "$le_container_name"
+
+if ! docker exec "$le_container_name" test -f "$acme_config_file"; then
+  echo "The $acme_config_file file does not exist."
+fi
+
+cert_create_time="$(docker exec "$le_container_name" grep "$acme_cert_create_time_key" "$acme_config_file" | cut -f2 -d\')"
+expected_renewal_days="${acme_renewal_days_key}'$global_renew'"
+expected_next_renew_time="${acme_next_renew_time_key}'$(($cert_create_time + $global_renew * 24 * 60 * 60 - 86400))'"
+actual_renewal_days="$(docker exec "$le_container_name" grep "$acme_renewal_days_key" "$acme_config_file")"
+actual_next_renew_time="$(docker exec "$le_container_name" grep "$acme_next_renew_time_key" "$acme_config_file")"
+
+if [[ "$expected_renewal_days" != "$actual_renewal_days" ]]; then
+  echo "Global renewal days is not correct"
+fi
+if [[ "$expected_next_renew_time" != "$actual_next_renew_time" ]]; then
+  echo "Global next renewal time is not correct"
+fi
+
+# Test per-container ACME_RENEW_AFTER override
+container_renew=30
+container_email_2="contact@${domains[1]}"
+acme_config_file_2="/etc/acme.sh/$container_email_2/${domains[1]}/${domains[1]}.conf"
+
+# Run a nginx container for ${domains[0]} with LETSENCRYPT_EMAIL and ACME_RENEW_AFTER set.
+run_nginx_container --hosts "${domains[1]}" \
+  --cli-args "--env LETSENCRYPT_EMAIL=${container_email_2}" \
+  --cli-args "--env ACME_RENEW_AFTER=$container_renew"
+
+# Wait for a symlink at /etc/nginx/certs/${domains[1]}.crt
+wait_for_symlink "${domains[1]}" "$le_container_name"
+
+if ! docker exec "$le_container_name" test -f "$acme_config_file_2"; then
+  echo "The $acme_config_file_2 file does not exist."
+fi
+
+cert_create_time_2="$(docker exec "$le_container_name" grep "$acme_cert_create_time_key" "$acme_config_file_2" | cut -f2 -d\')"
+expected_renewal_days_2="${acme_renewal_days_key}'$container_renew'"
+expected_next_renew_time_2="${acme_next_renew_time_key}'$(($cert_create_time_2 + $container_renew * 24 * 60 * 60 - 86400))'"
+actual_renewal_days_2="$(docker exec "$le_container_name" grep "$acme_renewal_days_key" "$acme_config_file_2")"
+actual_next_renew_time_2="$(docker exec "$le_container_name" grep "$acme_next_renew_time_key" "$acme_config_file_2")"
+
+if [[ "$expected_renewal_days_2" != "$actual_renewal_days_2" ]]; then
+  echo "Per-container renewal days is not correct"
+fi
+if [[ "$expected_next_renew_time_2" != "$actual_next_renew_time_2" ]]; then
+  echo "Per-container next renewal time is not correct"
+fi


### PR DESCRIPTION
This PR
- rename the global environment variable `DEFAULT_RENEW` to `ACME_RENEW_AFTER` to clarify what it does (while maintaining backward compatibility with the old variable for the time being)
- add support for `ACME_RENEW_AFTER` at the application container level in addition to the global acme-companion container level

@brakhane this feature was motivated by the introduction of certificate profiles support in #1230 , so if you have some time to spare I'd like to have your feedback on this 👍