### PR TITLE
feat: rsa 8192 and ec-521 private keys

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -232,7 +232,7 @@ function update_cert {
 
     local -n cert_keysize="LETSENCRYPT_${cid}_KEYSIZE"
     if [[ -z "$cert_keysize" ]] || \
-        [[ ! "$cert_keysize" =~ ^('2048'|'3072'|'4096'|'ec-256'|'ec-384')$ ]]; then
+        [[ ! "$cert_keysize" =~ ^('2048'|'3072'|'4096'|'8192'|'ec-256'|'ec-384'|'ec-521')$ ]]; then
         cert_keysize=$DEFAULT_KEY_SIZE
     fi
     params_issue_arr+=(--keylength "$cert_keysize")

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -102,7 +102,7 @@ The `LETSENCRYPT_EMAIL` environment variable must be a valid email and can be us
 
 #### Private key size
 
-The `LETSENCRYPT_KEYSIZE` environment variable determines the type and size of the requested key. Supported values are `2048`, `3072` and `4096` for RSA keys, and `ec-256` or `ec-384` for elliptic curve keys. The default is RSA 4096.  
+The `LETSENCRYPT_KEYSIZE` environment variable determines the type and size of the requested key. Supported values are `2048`, `3072`, `4096` or `8192` for RSA keys, and `ec-256`, `ec-384` or `ec-521` for elliptic curve keys. The default is RSA 4096.  
 To change the global default set the `DEFAULT_KEY_SIZE` environment variable on the **acme-companion** container to one of the supported values specified above.
 
 #### OCSP stapling

--- a/test/tests/private_keys/run.sh
+++ b/test/tests/private_keys/run.sh
@@ -30,8 +30,10 @@ key_types=( \
   ['2048']='Public-Key: (2048 bit)' \
   ['3072']='Public-Key: (3072 bit)' \
   ['4096']='Public-Key: (4096 bit)' \
+  ['8192']='Public-Key: (8192 bit)' \
   ['ec-256']='prime256v1' \
   ['ec-384']='secp384r1' \
+  ['ec-521']='secp521r1' \
 )
 
 for key in "${!key_types[@]}"; do


### PR DESCRIPTION
This PR add two missing possible values for `LETSENCRYPT_KEYSIZE`:
- `8192` for RSA keys
- `ec-521` for elliptic curve keys