### PR TITLE
feat: support for acme.sh --dnssleep

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -187,6 +187,7 @@ function update_cert {
     elif [[ "$acme_challenge" == "DNS-01" ]]; then
         # DNS-01 challenge
         local acmesh_dns_config_used='none'
+        local acmesh_dns_sleep_value='none'
 
         local default_acmesh_dns_api="${DEFAULT_ACMESH_DNS_API_CONFIG[DNS_API]}"
         [[ -n "$default_acmesh_dns_api" ]] && acmesh_dns_config_used='default'
@@ -202,20 +203,30 @@ function update_cert {
                 params_issue_arr+=(--dns "$default_acmesh_dns_api")
                 # Loop over defined variable for default acme.sh DNS api config
                 for key in "${!DEFAULT_ACMESH_DNS_API_CONFIG[@]}"; do
-                    [[ "$key" == "DNS_API" ]] && continue
-                    dns_api_keys+=("$key")
-                    local value="${DEFAULT_ACMESH_DNS_API_CONFIG[$key]}"
-                    local -x "$key"="$value"
+                    if [[ "$key" == "DNS_API" ]]; then
+                        continue
+                    elif [[ "$key" == "DNS_SLEEP" ]]; then
+                        acmesh_dns_sleep_value="${DEFAULT_ACMESH_DNS_API_CONFIG[$key]}"
+                    else
+                        dns_api_keys+=("$key")
+                        local value="${DEFAULT_ACMESH_DNS_API_CONFIG[$key]}"
+                        local -x "$key"="$value"
+                    fi
                 done
                 ;;
             'container')
                 params_issue_arr+=(--dns "$acmesh_dns_api")
                 # Loop over defined variable for per container acme.sh DNS api config
                 for key in "${!acmesh_dns_config[@]}"; do
-                    [[ "$key" == "DNS_API" ]] && continue
-                    dns_api_keys+=("$key")
-                    local value="${acmesh_dns_config[$key]}"
-                    local -x "$key"="$value"
+                    if [[ "$key" == "DNS_API" ]]; then
+                        continue
+                    elif [[ "$key" == "DNS_SLEEP" ]]; then
+                        acmesh_dns_sleep_value="${acmesh_dns_config[$key]}"
+                    else
+                        dns_api_keys+=("$key")
+                        local value="${acmesh_dns_config[$key]}"
+                        local -x "$key"="$value"
+                    fi
                 done
                 ;;
             *)
@@ -225,6 +236,16 @@ function update_cert {
         esac
 
         echo "Info: DNS challenge using $acmesh_dns_api DNS API with the following keys: ${dns_api_keys[*]} (${acmesh_dns_config_used} config)"
+        
+        if [[ "$acmesh_dns_sleep_value" != 'none' ]]; then
+            if [[ "$acmesh_dns_sleep_value" =~ ^[0-9]+$ ]]; then
+                params_issue_arr+=(--dnssleep "$acmesh_dns_sleep_value")
+                echo "Info: acme.sh will wait for $acmesh_dns_sleep_value seconds for all the txt records to propagate."
+            else
+                echo "Warning: the provided DNS_SLEEP value ($acmesh_dns_sleep_value) is not a valid integer, --dnssleep won't be passed to acme.sh." >&2
+            fi
+            
+        fi
     else 
         echo "Error: unknown ACME challenge method: $acme_challenge"
         return 1

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -14,6 +14,8 @@ The following environment variables are optional and parametrize the way the Let
 
 In order to switch to the DNS-01 ACME challenge, set the `ACME_CHALLENGE` environment variable to `DNS-01` on your acme-companion container. This will also require you to set the `ACMESH_DNS_API_CONFIG` environment variable to a JSON or YAML string containing the configuration for the DNS provider you are using. Inside the JSON or YAML string, the `DNS_API` property is always required and should be set to the name of the [acme.sh DNS API](https://github.com/acmesh-official/acme.sh/tree/3.1.3/dnsapi) you want to use.
 
+When using the DNS-01 ACME challenge, you can optionally configure the time (in seconds) that acme.sh should wait for DNS TXT records to propagate before attempting validation. This is done by adding the (optional) `DNS_SLEEP` property to the `ACMESH_DNS_API_CONFIG` environment variable.
+
 The other properties required will depend on the DNS provider you are using. For more information on the required properties for each DNS provider, please refer to the [acme.sh documentation](https://github.com/acmesh-official/acme.sh/wiki/dnsapi) (please keep in mind that nginxproxy/acme-companion is using a fixed version of acme.sh, so the documentation might include DNS providers that are not yet available in the version used by this image).
 
 Both `ACME_CHALLENGE` and `ACMESH_DNS_API_CONFIG` environment variables can also be set on the proxied application container, in which case they will override the values set on the acme-companion container, if any.
@@ -29,7 +31,7 @@ docker run --detach \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
     --env "DEFAULT_EMAIL=mail@yourdomain.tld" \
     --env "ACME_CHALLENGE=DNS-01" \
-    --env "ACMESH_DNS_API_CONFIG={'DNS_API': 'dns_cf', 'CF_Key': 'yourCloudflareGlobalApiKey', 'CF_Email': 'yourCloudflareAccountEmail'}" \
+    --env "ACMESH_DNS_API_CONFIG={'DNS_API': 'dns_cf', 'DNS_SLEEP': 900, 'CF_Key': 'yourCloudflareGlobalApiKey', 'CF_Email': 'yourCloudflareAccountEmail'}" \
     nginxproxy/acme-companion
 ```
 
@@ -50,6 +52,7 @@ services:
       ACME_CHALLENGE: DNS-01
       ACMESH_DNS_API_CONFIG: |-
         DNS_API: dns_cf
+        DNS_SLEEP: 900
         CF_Key: yourCloudflareGlobalApiKey
         CF_Email: yourCloudflareAccountEmail
     


### PR DESCRIPTION
This PR fixes #1242 by adding `DNS_SLEEP` to the `ACMESH_DNS_API_CONFIG` environment variable.

```yaml
services:
  # nginx proxy container omitted
    
  acme:
    image: nginxproxy/acme-companion
    container_name: nginx-proxy-acme
    volumes:
      - certs:/etc/nginx/certs
      - acme:/etc/acme.sh
      - /var/run/docker.sock:/var/run/docker.sock:ro
    environment:
      DEFAULT_EMAIL: mail@yourdomain.tld
      ACME_CHALLENGE: DNS-01
      ACMESH_DNS_API_CONFIG: |-
        DNS_API: dns_cf
        DNS_SLEEP: 900
        CF_Key: yourCloudflareGlobalApiKey
        CF_Email: yourCloudflareAccountEmail
    
    # app container omitted

volumes:
  certs:
  acme:
```