### PR TITLE
feat: add Docker API TLS client-certificate support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,9 @@ jobs:
           - test-name: standalone_ipv6
             setup: 2containers
             pebble-config: pebble-config.json
+          - test-name: docker_api_tls
+            setup: 2containers
+            pebble-config: pebble-config.json
     runs-on: ubuntu-latest
 
     steps:

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -23,6 +23,21 @@ function check_docker_socket {
             echo "Typically you should run your container with: '-v /var/run/docker.sock:$socket_file:ro'" >&2
             exit 1
         fi
+    elif parse_true "${DOCKER_TLS_VERIFY:-}"; then
+        if [[ -z "${DOCKER_CERT_PATH:-}" ]]; then
+            echo "Error: DOCKER_TLS_VERIFY is enabled but DOCKER_CERT_PATH is not set." >&2
+            echo "Set DOCKER_CERT_PATH to the in-container directory holding ca.pem, cert.pem and key.pem." >&2
+            exit 1
+        fi
+        local cert_file
+        for cert_file in ca.pem cert.pem key.pem; do
+            if [[ ! -r "${DOCKER_CERT_PATH}/${cert_file}" ]]; then
+                echo "Error: TLS certificate file ${DOCKER_CERT_PATH}/${cert_file} is missing or not readable." >&2
+                echo "DOCKER_CERT_PATH must point to an in-container directory containing readable ca.pem, cert.pem and key.pem files." >&2
+                echo "Typically you should mount your Docker client certificate directory, e.g.: '-v /path/to/docker/certs:${DOCKER_CERT_PATH}:ro'" >&2
+                exit 1
+            fi
+        done
     fi
 }
 

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -232,6 +232,11 @@ function docker_api {
     if [[ $DOCKER_HOST == unix://* ]]; then
         curl_opts+=(--unix-socket "${DOCKER_HOST#unix://}")
         scheme='http://localhost'
+    elif parse_true "${DOCKER_TLS_VERIFY:-}"; then
+        curl_opts+=(--cert "${DOCKER_CERT_PATH}/cert.pem")
+        curl_opts+=(--key "${DOCKER_CERT_PATH}/key.pem")
+        curl_opts+=(--cacert "${DOCKER_CERT_PATH}/ca.pem")
+        scheme="https://${DOCKER_HOST#*://}"
     else
         scheme="http://${DOCKER_HOST#*://}"
     fi

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -45,3 +45,24 @@ You can also create test certificates per container (see [Test certificates](./L
 * `RELOAD_NGINX_ONLY_ONCE` - The companion reload nginx configuration after every new or renewed certificate. Previously this was done only once per service loop, at the end of the loop (this was causing delayed availability of HTTPS enabled application when multiple new certificates where requested at once, see [issue #1147](https://github.com/nginx-proxy/acme-companion/issues/1147)). You can restore the previous behaviour if needed by setting the environment variable `RELOAD_NGINX_ONLY_ONCE` to `true`.
 
 * `DOCKER_CONTAINER_FILTERS` -  You can filter which containers are considered by acme-companion by using the `DOCKER_CONTAINER_FILTERS` environment variable (by default, acme-companion will consider all running containers). It takes a comma separated list of `key=value` pairs. For example, setting `DOCKER_CONTAINER_FILTERS` environment variable to `network=mynetwork` will cause acme-companion to consider only containers connected to the `mynetwork` network. See the [Docker CLI documentation](https://docs.docker.com/reference/cli/docker/container/ls/#filter) for details on available filters.
+
+* `DOCKER_HOST` - The Docker API endpoint acme-companion talks to. Defaults to `unix:///var/run/docker.sock` (the mounted Docker socket). To connect to a remote or TLS-protected Docker daemon over TCP, set it to `tcp://<host>:2376`.
+
+* `DOCKER_TLS_VERIFY` and `DOCKER_CERT_PATH` - Enable TLS client-certificate authentication when connecting to the Docker daemon over `tcp://`. Set `DOCKER_TLS_VERIFY` to `true` and `DOCKER_CERT_PATH` to the **in-container** path of a directory containing `ca.pem`, `cert.pem` and `key.pem`. These variable names and file names match the [Docker CLI convention](https://docs.docker.com/engine/security/protect-access/) and the ones used by **docker-gen**, so the same certificate directory can be shared across containers.
+
+    > **Important:** `DOCKER_CERT_PATH` is a path **inside the container**. You must mount your certificate directory into the container with a volume, otherwise the files will not be found and the container will exit on startup with an error.
+
+    For example, connecting to a TLS-protected Docker daemon over TCP (note that the Docker socket is **not** mounted in this case):
+
+    ```bash
+    $ docker run --detach \
+        --name nginx-proxy-acme \
+        --volumes-from nginx-proxy \
+        --volume certs:/etc/nginx/certs:rw \
+        --volume acme:/etc/acme.sh \
+        --volume /path/to/docker/certs:/docker-certs:ro \
+        --env "DOCKER_HOST=tcp://docker-host.example.com:2376" \
+        --env "DOCKER_TLS_VERIFY=true" \
+        --env "DOCKER_CERT_PATH=/docker-certs" \
+        nginxproxy/acme-companion
+    ```

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -46,7 +46,7 @@ You can also create test certificates per container (see [Test certificates](./L
 
 * `DOCKER_CONTAINER_FILTERS` -  You can filter which containers are considered by acme-companion by using the `DOCKER_CONTAINER_FILTERS` environment variable (by default, acme-companion will consider all running containers). It takes a comma separated list of `key=value` pairs. For example, setting `DOCKER_CONTAINER_FILTERS` environment variable to `network=mynetwork` will cause acme-companion to consider only containers connected to the `mynetwork` network. See the [Docker CLI documentation](https://docs.docker.com/reference/cli/docker/container/ls/#filter) for details on available filters.
 
-* `DOCKER_HOST` - The Docker API endpoint acme-companion talks to. Defaults to `unix:///var/run/docker.sock` (the mounted Docker socket). To connect to a remote or TLS-protected Docker daemon over TCP, set it to `tcp://<host>:2376`.
+* `DOCKER_HOST` - The Docker API endpoint acme-companion talks to. Defaults to `unix:///var/run/docker.sock` (the mounted Docker socket). To connect to a remote or TLS-protected Docker daemon over TCP, set it to `tcp://<host>:<port>` (the conventional Docker TLS port is `2376`).
 
 * `DOCKER_TLS_VERIFY` and `DOCKER_CERT_PATH` - Enable TLS client-certificate authentication when connecting to the Docker daemon over `tcp://`. Set `DOCKER_TLS_VERIFY` to `true` and `DOCKER_CERT_PATH` to the **in-container** path of a directory containing `ca.pem`, `cert.pem` and `key.pem`. These variable names and file names match the [Docker CLI convention](https://docs.docker.com/engine/security/protect-access/) and the ones used by **docker-gen**, so the same certificate directory can be shared across containers.
 

--- a/test/config.sh
+++ b/test/config.sh
@@ -4,6 +4,7 @@ set -e
 globalTests+=(
 	docker_api
 	docker_api_legacy
+	docker_api_tls
 	location_config
 	debug_acmesh_log
 	certs_single

--- a/test/tests/docker_api_tls/expected-std-out.txt
+++ b/test/tests/docker_api_tls/expected-std-out.txt
@@ -1,0 +1,8 @@
+## tls-verify-true-get
+-s --cert /docker-certs/cert.pem --key /docker-certs/key.pem --cacert /docker-certs/ca.pem -X GET https://docker:2376/version
+## tls-verify-true-post
+-s --cert /docker-certs/cert.pem --key /docker-certs/key.pem --cacert /docker-certs/ca.pem -H Content-Type: application/json -X POST https://docker:2376/containers/test/restart
+## tls-verify-false-get
+-s -X GET http://docker:2376/version
+## unix-socket-get
+-s --unix-socket /var/run/docker.sock -X GET http://localhost/version

--- a/test/tests/docker_api_tls/run.sh
+++ b/test/tests/docker_api_tls/run.sh
@@ -2,24 +2,17 @@
 
 ## Test for Docker API TLS client-certificate support (DOCKER_TLS_VERIFY / DOCKER_CERT_PATH).
 ##
-## Two complementary checks:
-##   1. (default, runs in CI) Deterministic verification that docker_api builds the
-##      expected curl invocation for each transport, by stubbing curl. This needs no
-##      external TLS daemon and is therefore stable on CI runners.
-##   2. (optional, RUN_TLS_INTEGRATION=1) A real TLS handshake against the Docker
-##      socket exposed over tcp:// by a socat sidecar, to confirm end-to-end behaviour.
+## Deterministic verification that docker_api builds the expected curl invocation for
+## each transport, by stubbing curl. This needs no external TLS daemon and is therefore
+## stable on CI runners.
 ##
 ## This test is transport-focused and produces identical output regardless of the
 ## SETUP (2containers / 3containers); it is registered to run once via the CI matrix.
 
-# ---------------------------------------------------------------------------
-# 1. curl-stub verification of the curl invocation built by docker_api
-# ---------------------------------------------------------------------------
-
 # Replace curl with a stub that prints the arguments it would have received, then
 # exercise docker_api over each transport in an isolated subshell (to avoid the
 # bash quirk where `VAR=x function_call` leaks VAR into the calling shell).
-read -r -d '' commands <<'EOF'
+commands="$(cat <<'EOF'
 curl() { printf '%s\n' "$*"; }
 source /app/functions.sh
 echo '## tls-verify-true-get'
@@ -31,73 +24,6 @@ echo '## tls-verify-false-get'
 echo '## unix-socket-get'
 ( export DOCKER_HOST='unix:///var/run/docker.sock'; docker_api '/version' )
 EOF
+)"
 
 docker run --rm "$1" bash -c "$commands" 2>&1
-
-# ---------------------------------------------------------------------------
-# 2. Optional real TLS handshake against a socat sidecar (local only)
-# ---------------------------------------------------------------------------
-
-if [[ "${RUN_TLS_INTEGRATION:-}" != "1" ]]; then
-  exit 0
-fi
-
-net='docker-api-tls-net'
-proxy='docker-api-tls-proxy'
-certs_dir="$(mktemp -d)"
-server_dir="${certs_dir}/server"
-client_dir="${certs_dir}/client"
-mkdir -p "$server_dir" "$client_dir"
-
-function cleanup_integration {
-  docker rm --force "$proxy" &> /dev/null
-  docker network rm "$net" &> /dev/null
-  rm -rf "$certs_dir"
-}
-trap cleanup_integration EXIT
-
-# Generate a CA, a server certificate (SAN matching the sidecar's network alias)
-# and a client certificate, all signed by the CA.
-openssl genrsa -out "${certs_dir}/ca-key.pem" 2048 &> /dev/null
-openssl req -x509 -new -key "${certs_dir}/ca-key.pem" -days 1 -subj '/CN=test-ca' \
-  -out "${certs_dir}/ca.pem" &> /dev/null
-
-openssl genrsa -out "${server_dir}/key.pem" 2048 &> /dev/null
-openssl req -new -key "${server_dir}/key.pem" -subj "/CN=${proxy}" \
-  -out "${server_dir}/csr.pem" &> /dev/null
-openssl x509 -req -in "${server_dir}/csr.pem" \
-  -CA "${certs_dir}/ca.pem" -CAkey "${certs_dir}/ca-key.pem" -CAcreateserial \
-  -days 1 -extfile <(printf 'subjectAltName=DNS:%s' "$proxy") \
-  -out "${server_dir}/cert.pem" &> /dev/null
-cp "${certs_dir}/ca.pem" "${server_dir}/ca.pem"
-
-openssl genrsa -out "${client_dir}/key.pem" 2048 &> /dev/null
-openssl req -new -key "${client_dir}/key.pem" -subj '/CN=test-client' \
-  -out "${client_dir}/csr.pem" &> /dev/null
-openssl x509 -req -in "${client_dir}/csr.pem" \
-  -CA "${certs_dir}/ca.pem" -CAkey "${certs_dir}/ca-key.pem" -CAcreateserial \
-  -days 1 -out "${client_dir}/cert.pem" &> /dev/null
-cp "${certs_dir}/ca.pem" "${client_dir}/ca.pem"
-
-docker network create "$net" &> /dev/null
-
-# Expose the Docker socket over tcp://:2376 with mandatory client-cert verification.
-docker run --rm -d \
-  --name "$proxy" \
-  --network "$net" \
-  -v /var/run/docker.sock:/var/run/docker.sock:ro \
-  -v "${server_dir}:/certs:ro" \
-  alpine/socat \
-  "OPENSSL-LISTEN:2376,reuseaddr,fork,cert=/certs/cert.pem,key=/certs/key.pem,cafile=/certs/ca.pem,verify=1" \
-  "UNIX-CONNECT:/var/run/docker.sock" > /dev/null
-
-# Query the Docker API over TLS through docker_api and print the API version.
-integration_commands='source /app/functions.sh; docker_api "/version" | jq -r ".ApiVersion // \"no-response\""'
-docker run --rm \
-  --network "$net" \
-  -e "DOCKER_HOST=tcp://${proxy}:2376" \
-  -e "DOCKER_TLS_VERIFY=true" \
-  -e "DOCKER_CERT_PATH=/docker-certs" \
-  -v "${client_dir}:/docker-certs:ro" \
-  "$1" \
-  bash -c "$integration_commands" 2>&1

--- a/test/tests/docker_api_tls/run.sh
+++ b/test/tests/docker_api_tls/run.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+## Test for Docker API TLS client-certificate support (DOCKER_TLS_VERIFY / DOCKER_CERT_PATH).
+##
+## Two complementary checks:
+##   1. (default, runs in CI) Deterministic verification that docker_api builds the
+##      expected curl invocation for each transport, by stubbing curl. This needs no
+##      external TLS daemon and is therefore stable on CI runners.
+##   2. (optional, RUN_TLS_INTEGRATION=1) A real TLS handshake against the Docker
+##      socket exposed over tcp:// by a socat sidecar, to confirm end-to-end behaviour.
+##
+## This test is transport-focused and produces identical output regardless of the
+## SETUP (2containers / 3containers); it is registered to run once via the CI matrix.
+
+# ---------------------------------------------------------------------------
+# 1. curl-stub verification of the curl invocation built by docker_api
+# ---------------------------------------------------------------------------
+
+# Replace curl with a stub that prints the arguments it would have received, then
+# exercise docker_api over each transport in an isolated subshell (to avoid the
+# bash quirk where `VAR=x function_call` leaks VAR into the calling shell).
+read -r -d '' commands <<'EOF'
+curl() { printf '%s\n' "$*"; }
+source /app/functions.sh
+echo '## tls-verify-true-get'
+( export DOCKER_HOST='tcp://docker:2376' DOCKER_TLS_VERIFY='true' DOCKER_CERT_PATH='/docker-certs'; docker_api '/version' )
+echo '## tls-verify-true-post'
+( export DOCKER_HOST='tcp://docker:2376' DOCKER_TLS_VERIFY='true' DOCKER_CERT_PATH='/docker-certs'; docker_api '/containers/test/restart' 'POST' )
+echo '## tls-verify-false-get'
+( export DOCKER_HOST='tcp://docker:2376' DOCKER_TLS_VERIFY='false' DOCKER_CERT_PATH='/docker-certs'; docker_api '/version' )
+echo '## unix-socket-get'
+( export DOCKER_HOST='unix:///var/run/docker.sock'; docker_api '/version' )
+EOF
+
+docker run --rm "$1" bash -c "$commands" 2>&1
+
+# ---------------------------------------------------------------------------
+# 2. Optional real TLS handshake against a socat sidecar (local only)
+# ---------------------------------------------------------------------------
+
+if [[ "${RUN_TLS_INTEGRATION:-}" != "1" ]]; then
+  exit 0
+fi
+
+net='docker-api-tls-net'
+proxy='docker-api-tls-proxy'
+certs_dir="$(mktemp -d)"
+server_dir="${certs_dir}/server"
+client_dir="${certs_dir}/client"
+mkdir -p "$server_dir" "$client_dir"
+
+function cleanup_integration {
+  docker rm --force "$proxy" &> /dev/null
+  docker network rm "$net" &> /dev/null
+  rm -rf "$certs_dir"
+}
+trap cleanup_integration EXIT
+
+# Generate a CA, a server certificate (SAN matching the sidecar's network alias)
+# and a client certificate, all signed by the CA.
+openssl genrsa -out "${certs_dir}/ca-key.pem" 2048 &> /dev/null
+openssl req -x509 -new -key "${certs_dir}/ca-key.pem" -days 1 -subj '/CN=test-ca' \
+  -out "${certs_dir}/ca.pem" &> /dev/null
+
+openssl genrsa -out "${server_dir}/key.pem" 2048 &> /dev/null
+openssl req -new -key "${server_dir}/key.pem" -subj "/CN=${proxy}" \
+  -out "${server_dir}/csr.pem" &> /dev/null
+openssl x509 -req -in "${server_dir}/csr.pem" \
+  -CA "${certs_dir}/ca.pem" -CAkey "${certs_dir}/ca-key.pem" -CAcreateserial \
+  -days 1 -extfile <(printf 'subjectAltName=DNS:%s' "$proxy") \
+  -out "${server_dir}/cert.pem" &> /dev/null
+cp "${certs_dir}/ca.pem" "${server_dir}/ca.pem"
+
+openssl genrsa -out "${client_dir}/key.pem" 2048 &> /dev/null
+openssl req -new -key "${client_dir}/key.pem" -subj '/CN=test-client' \
+  -out "${client_dir}/csr.pem" &> /dev/null
+openssl x509 -req -in "${client_dir}/csr.pem" \
+  -CA "${certs_dir}/ca.pem" -CAkey "${certs_dir}/ca-key.pem" -CAcreateserial \
+  -days 1 -out "${client_dir}/cert.pem" &> /dev/null
+cp "${certs_dir}/ca.pem" "${client_dir}/ca.pem"
+
+docker network create "$net" &> /dev/null
+
+# Expose the Docker socket over tcp://:2376 with mandatory client-cert verification.
+docker run --rm -d \
+  --name "$proxy" \
+  --network "$net" \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v "${server_dir}:/certs:ro" \
+  alpine/socat \
+  "OPENSSL-LISTEN:2376,reuseaddr,fork,cert=/certs/cert.pem,key=/certs/key.pem,cafile=/certs/ca.pem,verify=1" \
+  "UNIX-CONNECT:/var/run/docker.sock" > /dev/null
+
+# Query the Docker API over TLS through docker_api and print the API version.
+integration_commands='source /app/functions.sh; docker_api "/version" | jq -r ".ApiVersion // \"no-response\""'
+docker run --rm \
+  --network "$net" \
+  -e "DOCKER_HOST=tcp://${proxy}:2376" \
+  -e "DOCKER_TLS_VERIFY=true" \
+  -e "DOCKER_CERT_PATH=/docker-certs" \
+  -v "${client_dir}:/docker-certs:ro" \
+  "$1" \
+  bash -c "$integration_commands" 2>&1


### PR DESCRIPTION
## What

Add support for connecting to a TLS-protected Docker daemon over `tcp://` using client-certificate authentication.

This revives and completes #673, which has been open since 2020, addressing the maintainer's requested changes.

## Why

When the Docker daemon is only reachable over a `tcp://` endpoint secured with `--tlsverify`, `docker_api` previously always used plain `http://`, so every API call failed. acme-companion could not be used against a remote/secured Docker host.

## How

Mirrors the Docker CLI and **docker-gen** convention so a single certificate directory can be shared across containers:

- **`DOCKER_TLS_VERIFY`** — set to `true` (or `True`/`TRUE`/`1`) to enable TLS client auth.
- **`DOCKER_CERT_PATH`** — in-container directory containing `ca.pem`, `cert.pem`, `key.pem`.

Changes:

- **`app/functions.sh`** — `docker_api` gains a mutually-exclusive TLS branch (after the unix-socket branch) that appends `--cert`/`--key`/`--cacert` and switches the scheme to `https://`. It is gated by the existing `parse_true` helper, so only `true`/`True`/`TRUE`/`1` enable it (addresses the review request to not accept any non-empty value).
- **`app/entrypoint.sh`** — `check_docker_socket` now validates, when TLS is enabled, that `DOCKER_CERT_PATH` is set and the three certificate files are readable, failing fast with an actionable error (with a `-v` mount example) instead of a silent curl failure.
- **`docs/Container-configuration.md`** — documents the variables and emphasises that `DOCKER_CERT_PATH` is an **in-container** path that must be volume-mounted.
- **`test/tests/docker_api_tls/`** — new test that stubs `curl` and asserts the exact invocation `docker_api` builds for each transport (TLS GET/POST, TLS disabled, unix socket), verifying both the cert flags and the `parse_true` gating. It needs no external TLS daemon, so it is deterministic on CI runners. Registered in `test/config.sh` and added to the CI matrix (`.github/workflows/test.yml`).

## Maintainer requests from #673 addressed

1. ✅ `DOCKER_TLS_VERIFY` validated via the project's `true/True/TRUE/1` convention (`parse_true`).
2. ✅ Docs clarify the path is in-container and requires a volume mount.
3. ✅ Tests added (resolves `status/pr-needs-tests`).

## Testing

- `docker_api_tls` passes under both `2containers` and `3containers` (the test is transport-focused and produces identical output regardless of the setup).
- Negative control (corrupted expected output) correctly fails — comparison is effective.
- Existing `docker_api` test passes under both setups (no regression).
- `shellcheck` clean on all modified scripts.

Closes #754

Supersedes #673 (revives that proposal with the maintainer's requested changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
