### PR TITLE
feat: surface acme.sh log to container output when DEBUG=1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,9 @@ jobs:
           - test-name: acme_eab
             setup: 3containers
             pebble-config: pebble-config-eab.json
+          - test-name: debug_acmesh_log
+            setup: 2containers
+            pebble-config: pebble-config.json
     runs-on: ubuntu-latest
 
     steps:

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -151,7 +151,17 @@ function update_cert {
 
     # Base CLI parameters array, used for both --register-account and --issue
     local -a params_base_arr
-    params_base_arr+=(--log /dev/null)
+    # In debug mode, surface acme.sh's own detailed log on the container output
+    # (visible through docker logs) instead of discarding it.
+    # Log to /dev/stderr (not /dev/stdout): acme.sh captures the stdout of its
+    # internal helpers through command substitution (e.g. response="$(_post ...)"),
+    # so writing the log to stdout would pollute those captures and break the ACME
+    # exchange. stderr is never captured that way and still reaches docker logs.
+    if [[ "$DEBUG" == 1 ]]; then
+        params_base_arr+=(--log /dev/stderr)
+    else
+        params_base_arr+=(--log /dev/null)
+    fi
     params_base_arr+=(--useragent "nginx-proxy/acme-companion/$COMPANION_VERSION (acme.sh/$ACMESH_VERSION)")
     [[ "$DEBUG" == 1 ]] && params_base_arr+=(--debug 2)
 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -151,12 +151,8 @@ function update_cert {
 
     # Base CLI parameters array, used for both --register-account and --issue
     local -a params_base_arr
-    # In debug mode, surface acme.sh's own detailed log on the container output
-    # (visible through docker logs) instead of discarding it.
-    # Log to /dev/stderr (not /dev/stdout): acme.sh captures the stdout of its
-    # internal helpers through command substitution (e.g. response="$(_post ...)"),
-    # so writing the log to stdout would pollute those captures and break the ACME
-    # exchange. stderr is never captured that way and still reaches docker logs.
+    # In debug mode, route acme.sh's own log to docker logs instead of discarding it.
+    # Use stderr, not stdout, which acme.sh captures via command substitution.
     if [[ "$DEBUG" == 1 ]]; then
         params_base_arr+=(--log /dev/stderr)
     else

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -18,7 +18,7 @@ $ docker run --detach \
 ```
 You can also create test certificates per container (see [Test certificates](./Let's-Encrypt-and-ACME.md#test-certificates))
 
-* `DEBUG` - Set it to `1` to enable debugging of the entrypoint script and generation of LetsEncrypt certificates, which could help you pin point any configuration issues.
+* `DEBUG` - Set it to `1` to enable debugging of the entrypoint script and generation of LetsEncrypt certificates, which could help you pin point any configuration issues. When enabled, `acme.sh`'s own detailed log is also sent to the container output (visible through `docker logs`) instead of being discarded, which is especially useful for diagnosing DNS-01 challenge failures.
 
 * `RENEW_PRIVATE_KEYS` - Set it to `false` to make `acme.sh` reuse previously generated private key for each certificate instead of creating a new one on certificate renewal. Reusing private keys can help if you intend to use [HPKP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning), but please note that HPKP has been deprecated by Google's Chrome and that it is therefore strongly discouraged to use it at all.
 

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -18,7 +18,7 @@ $ docker run --detach \
 ```
 You can also create test certificates per container (see [Test certificates](./Let's-Encrypt-and-ACME.md#test-certificates))
 
-* `DEBUG` - Set it to `1` to enable debugging of the entrypoint script and generation of LetsEncrypt certificates, which could help you pin point any configuration issues. When enabled, `acme.sh`'s own detailed log is also sent to the container output (visible through `docker logs`) instead of being discarded, which is especially useful for diagnosing DNS-01 challenge failures.
+* `DEBUG` - Set it to `1` to enable debugging of the entrypoint script and generation of LetsEncrypt certificates, which could help you pinpoint any configuration issues. When enabled, `acme.sh`'s own detailed log is also sent to the container output (visible through `docker logs`) instead of being discarded, which is especially useful for diagnosing DNS-01 challenge failures.
 
 * `RENEW_PRIVATE_KEYS` - Set it to `false` to make `acme.sh` reuse previously generated private key for each certificate instead of creating a new one on certificate renewal. Reusing private keys can help if you intend to use [HPKP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning), but please note that HPKP has been deprecated by Google's Chrome and that it is therefore strongly discouraged to use it at all.
 

--- a/docs/Invalid-authorizations.md
+++ b/docs/Invalid-authorizations.md
@@ -1,6 +1,6 @@
 ## Troubleshooting failing authorizations
 
-The first two things to do in case of failing authorization are to run the **acme-companion** container with the environment variable `DEBUG=1` to enable the more detailed error messages, and to [request test certificates](./Let's-Encrypt-and-ACME.md#test-certificates) while troubleshooting the issue.
+The first two things to do in case of failing authorization are to run the **acme-companion** container with the environment variable `DEBUG=1` to enable the more detailed error messages, and to [request test certificates](./Let's-Encrypt-and-ACME.md#test-certificates) while troubleshooting the issue. With `DEBUG=1`, `acme.sh`'s own detailed log is also written to the container output, so `docker logs <acme-companion container>` will show the full reason behind a failing challenge (this is particularly helpful for DNS-01 challenges).
 
 Common causes of of failing authorizations:
 

--- a/test/config.sh
+++ b/test/config.sh
@@ -5,6 +5,7 @@ globalTests+=(
 	docker_api
 	docker_api_legacy
 	location_config
+	debug_acmesh_log
 	certs_single
 	certs_san
 	certs_single_domain

--- a/test/tests/debug_acmesh_log/run.sh
+++ b/test/tests/debug_acmesh_log/run.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+## Test that, with DEBUG=1, acme.sh's own log is routed to the container output
+## (--log /dev/stderr) instead of being discarded (--log /dev/null). See issue #918.
+
+if [[ -z $GITHUB_ACTIONS ]]; then
+  le_container_name="$(basename "${0%/*}")_$(date "+%Y-%m-%d_%H.%M.%S")"
+else
+  le_container_name="$(basename "${0%/*}")"
+fi
+# run_le_container starts the companion with DEBUG=1 by default.
+run_le_container "${1:?}" "$le_container_name"
+
+# Create the $domains array from comma separated domains in TEST_DOMAINS.
+IFS=',' read -r -a domains <<< "$TEST_DOMAINS"
+domain="${domains[0]}"
+
+# Cleanup function with EXIT trap
+function cleanup {
+  # Remove the remaining Nginx container silently.
+  docker rm --force "$domain" &> /dev/null
+  # Cleanup the files created by this run of the test to avoid foiling following test(s).
+  docker exec "$le_container_name" /app/cleanup_test_artifacts
+  # Stop the LE container
+  docker stop "$le_container_name" > /dev/null
+}
+trap cleanup EXIT
+
+# Trigger a certificate issuance so that acme.sh actually runs.
+run_nginx_container --hosts "$domain"
+
+# Wait for the certificate to be issued (symlink created).
+if ! wait_for_symlink "$domain" "$le_container_name" "./${domain}/fullchain.pem" ; then
+  echo "Certificate for $domain was not issued, cannot check acme.sh log routing."
+fi
+
+le_logs="$(docker logs "$le_container_name" 2>&1)"
+
+# With DEBUG=1, acme.sh must be invoked with '--log /dev/stderr' ...
+if ! grep -q -- '--log /dev/stderr' <<< "$le_logs"; then
+  echo "acme.sh was not invoked with '--log /dev/stderr' while DEBUG=1."
+elif [[ "${DRY_RUN:-}" == 1 ]]; then
+  echo "acme.sh was invoked with '--log /dev/stderr' while DEBUG=1."
+fi
+
+# ... and must never fall back to '--log /dev/null' while DEBUG=1.
+if grep -q -- '--log /dev/null' <<< "$le_logs"; then
+  echo "acme.sh was still invoked with '--log /dev/null' while DEBUG=1."
+elif [[ "${DRY_RUN:-}" == 1 ]]; then
+  echo "acme.sh was not invoked with '--log /dev/null' while DEBUG=1."
+fi
+
+docker stop "$domain" > /dev/null


### PR DESCRIPTION
## What

When `DEBUG=1`, route acme.sh's own `--log` to `/dev/stderr` so it shows up in `docker logs`, instead of always discarding it to `/dev/null`.

## Why

`app/letsencrypt_service` invoked acme.sh with a hardcoded `--log /dev/null` for **every** call. As a result, even with `DEBUG=1` set, acme.sh's own detailed log — the part that actually explains *why* a challenge failed — was thrown away, and the `Please check log file for more details: /dev/null` hint led nowhere. This is especially painful for **DNS-01** challenges, where that log is often the only place the failure reason appears.

This revives #918 (open since 2022, label `status/needs-more-info`). Users had to resort to `sed`-patching the script inside the container as a workaround.

## How

Gate the `--log` destination on `DEBUG`, reusing the existing `[[ "$DEBUG" == 1 ]]` idiom already used a few lines below for `--debug 2`:

```bash
if [[ "$DEBUG" == 1 ]]; then
    params_base_arr+=(--log /dev/stderr)
else
    params_base_arr+=(--log /dev/null)
fi
```

- `params_base_arr` is shared by `--register-account`, `--update-account` and `--issue`, so one change covers every acme.sh invocation.
- `letsencrypt_service` runs in the foreground (`app/start.sh`), so `/dev/stderr` flows straight to `docker logs`.
- **`/dev/stderr`, not `/dev/stdout`:** acme.sh captures the stdout of its internal helpers via command substitution (e.g. `response="$(_post ...)"`), and `--log` writes into that captured stdout, which could corrupt the ACME exchange. stderr is not captured that way and still reaches `docker logs`.
- **Non-debug runs are unchanged** (`--log /dev/null`). The verbose acme.sh log only appears under `DEBUG=1`, where extra output is expected — this addresses @buchdag's earlier concern about mixing the log-file output with stdout/stderr in normal operation.

## Addressing the maintainer's question (#918)

> The fact that the log file and the stdin / stderr log contains different information would be very awkward.

By scoping this strictly to `DEBUG=1`, the interleaving only happens in the explicit debugging mode, where users already opt into verbose output. Normal operation is untouched.

## Changes

- `app/letsencrypt_service` — DEBUG-gated `--log` destination.
- `docs/Container-configuration.md`, `docs/Invalid-authorizations.md` — document the behaviour.
- `test/tests/debug_acmesh_log/` — new integration test asserting a DEBUG issuance calls acme.sh with `--log /dev/stderr` and never `--log /dev/null`; registered in `test/config.sh` and the CI matrix.

## Testing

- New `debug_acmesh_log` test added (runs in CI under the 2containers setup).
- Verified locally that acme.sh genuinely surfaces its detailed log under `DEBUG=1` (and that normal runs still discard it via `/dev/null`). While prototyping the routing, an `--issue` run emitted **9341 bytes** of acme.sh log with `--log` enabled vs **1459 bytes** with `--log /dev/null`, confirming the log is real and substantial; the final implementation routes it to `/dev/stderr` (see the stdout note above).
- `shellcheck` clean on the modified script and the new test.

Closes #918
