### PR TITLE
test: fix flaky force_renew test (detect renewal by serial)

### DIFF
--- a/test/tests/force_renew/run.sh
+++ b/test/tests/force_renew/run.sh
@@ -36,8 +36,7 @@ sleep 5
 # Issue a forced renewal (capture the output so a failure is diagnosable).
 renew_output="$(docker exec "$le_container_name" /app/force_renew 2>&1)"
 
-# A renewal re-issues the cert, so its serial must change. We check the serial rather
-# than the expiration date, which is unreliable here (the Pebble test profiles differ).
+# A renewal re-issues the cert, so its serial must change.
 timeout=$(($(date +%s) + 30))
 second_serial="$first_serial"
 while [[ $(date +%s) -lt $timeout ]]; do

--- a/test/tests/force_renew/run.sh
+++ b/test/tests/force_renew/run.sh
@@ -26,42 +26,33 @@ trap cleanup EXIT
 # Run a nginx container for ${domains[0]}.
 run_nginx_container --hosts "${domains[0]}"
 
-# Wait for a symlink at /etc/nginx/certs/${domains[0]}.crt
-# Grab the expiration time of the certificate
+# Wait for the certificate to be issued, then record its serial number.
 wait_for_symlink "${domains[0]}" "$le_container_name"
-first_cert_expire="$(get_cert_date_epoch expiration "${domains[0]}" "$le_container_name")"
+first_serial="$(get_cert_serial "${domains[0]}" "$le_container_name")"
 
 # Just to be sure
 sleep 5
 
-# Issue a forced renewal
-docker exec "$le_container_name" /app/force_renew &> /dev/null
+# Issue a forced renewal (capture the output so a failure is diagnosable).
+renew_output="$(docker exec "$le_container_name" /app/force_renew 2>&1)"
 
-# Poll until expiration date changes or timeout
-# Use a longer sleep and add error handling for transient states
+# A renewal re-issues the cert, so its serial must change. We check the serial rather
+# than the expiration date, which is unreliable here (the Pebble test profiles differ).
 timeout=$(($(date +%s) + 30))
-second_cert_expire="$first_cert_expire"
+second_serial="$first_serial"
 while [[ $(date +%s) -lt $timeout ]]; do
-  # Try to get the new expiration date, but handle errors gracefully
-  new_expire="$(get_cert_date_epoch expiration "${domains[0]}" "$le_container_name" 2>/dev/null || echo "$first_cert_expire")"
-  
-  # Only update if we got a valid value (not empty and numeric)
-  if [[ -n "$new_expire" ]] && [[ "$new_expire" =~ ^[0-9]+$ ]]; then
-    second_cert_expire="$new_expire"
-    
-    # If the new certificate has a later expiration, renewal succeeded
-    if [[ $second_cert_expire -gt $first_cert_expire ]]; then
-      [[ "${DRY_RUN:-}" == 1 ]] && echo "Certificate for ${domains[0]} was correctly renewed."
-      break
-    fi
+  new_serial="$(get_cert_serial "${domains[0]}" "$le_container_name" 2>/dev/null || true)"
+  if [[ -n "$new_serial" && "$new_serial" != "$first_serial" ]]; then
+    second_serial="$new_serial"
+    [[ "${DRY_RUN:-}" == 1 ]] && echo "Certificate for ${domains[0]} was correctly renewed."
+    break
   fi
-  
   sleep 2
 done
 
-# Final check - verify renewal actually happened
-if ! [[ $second_cert_expire -gt $first_cert_expire ]]; then
-  echo "Certificate for ${domains[0]} was not correctly renewed within 30s."
-  echo "First certificate expiration epoch : $first_cert_expire."
-  echo "Second certificate expiration epoch : $second_cert_expire."
+# Final check - verify the certificate was actually re-issued.
+if [[ "$second_serial" == "$first_serial" ]]; then
+  echo "Certificate for ${domains[0]} was not correctly renewed within 30s (serial unchanged: $first_serial)."
+  echo "force_renew output:"
+  echo "$renew_output"
 fi

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -349,9 +349,6 @@ function get_cert_date_epoch {
 export -f get_cert_date_epoch
 
 # Get the serial number of the certificate for domain $1 inside container $2.
-# The serial changes on every (re-)issuance, so it is a reliable signal that a
-# certificate was renewed (unlike the expiration date, which depends on the CA's
-# certificate profile / validity period).
 function get_cert_serial {
   local domain="${1:?}"
   local name="${2:?}"

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -348,6 +348,17 @@ function get_cert_date_epoch {
 }
 export -f get_cert_date_epoch
 
+# Get the serial number of the certificate for domain $1 inside container $2.
+# The serial changes on every (re-)issuance, so it is a reliable signal that a
+# certificate was renewed (unlike the expiration date, which depends on the CA's
+# certificate profile / validity period).
+function get_cert_serial {
+  local domain="${1:?}"
+  local name="${2:?}"
+  docker exec "$name" openssl x509 -noout -serial -in "/etc/nginx/certs/$domain.crt" | cut -d '=' -f 2
+}
+export -f get_cert_serial
+
 # Get the certificate validity period in seconds of domain $1 inside container $2
 function get_cert_validity_seconds {
   local domain="${1:?}"


### PR DESCRIPTION
## What

Make the `force_renew` integration test reliable. It has been failing intermittently in CI (maintainers have had to re-run it to get a green build).

## Why

The test forced a renewal and then polled for the certificate's **expiration date** (`notAfter`) to increase. That signal is unreliable: `test/setup/pebble/pebble-config.json` defines several certificate profiles with different validity periods (5y default, 1y, 6-day), and a renewed certificate can be issued under a *different* profile than the original — giving it an **earlier** `notAfter` even though the renewal succeeded. The poll then never sees `notAfter` increase and the test fails after 30s.

Example from a failed run:

```
First  certificate expiration epoch : 1939542803   # issued + ~5y  (default profile, 157766400s)
Second certificate expiration epoch : 1813312416   # issued + ~1y  (long-lived profile, 31536000s)
```

The two issuances were only ~13s apart (so the renewal *did* happen), but the renewed cert got a shorter validity, so `notAfter` went backwards.

## How

Detect the renewal by the certificate **serial number**, which changes on every (re-)issuance regardless of profile, validity period or timing:

- `test/tests/test-functions.sh` — add a `get_cert_serial` helper.
- `test/tests/force_renew/run.sh` — compare the serial before/after the forced renewal instead of the expiration date, and capture the `force_renew` output so a genuine failure is diagnosable (it was previously discarded to `/dev/null`).

Test-only change; no product code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
