### PR TITLE
fix: cert_status reports valid certs as EXPIRED when the chain can't be verified

### DIFF
--- a/app/cert_status
+++ b/app/cert_status
@@ -48,6 +48,11 @@ for cert in /etc/nginx/certs/*/fullchain.pem; do
             echo "$verify"
             # Print certificate info.
             print_cert_info "$cert"
+        elif openssl x509 -checkend 0 -noout -in "$cert" &> /dev/null; then
+            # Chain failed to verify but the leaf itself is still valid (not expired).
+            echo "${cert}: OK (chain verification failed)"
+            # Print certificate info.
+            print_cert_info "$cert"
         else
             echo "${cert}: EXPIRED"
             # Print certificate info.


### PR DESCRIPTION
## What

`/app/cert_status` no longer reports a still-valid certificate as `EXPIRED` just because its chain fails to verify.

## Why

`cert_status` ran `openssl verify -untrusted chain.pem fullchain.pem` and labelled **any** failure as `EXPIRED`:

```bash
if verify=$(openssl verify ...); then
    echo "$verify"
else
    echo "${cert}: EXPIRED"   # ← every verify failure becomes "EXPIRED"
fi
```

But `openssl verify` also fails when a **trust anchor in the chain has expired** (the classic DST Root CA X3 expiry, Sep 2021) even though the leaf certificate itself is still valid. Users with valid, freshly-renewed certificates saw them reported as `EXPIRED` (#881), which is misleading (the certificate/renewal logic itself was fine).

## How

Determine expiry from the **leaf certificate's own `notAfter`** using `openssl x509 -checkend 0`, rather than treating a chain-verification failure as expiry:

- If `openssl verify` succeeds → `OK` (unchanged).
- If it fails but the leaf is still valid → `OK (chain verification failed)` (was wrongly `EXPIRED`).
- If the leaf is actually expired → `EXPIRED` (unchanged).

Added `test/tests/cert_status/` — a deterministic test (no ACME server needed) that generates a valid self-signed cert (chain unverifiable) and an expired one, and asserts the valid one is **not** reported `EXPIRED` while the expired one **is**.

## Testing

- New `cert_status` test passes locally and is registered in `test/config.sh` + the CI matrix.
- Manually confirmed the output:
  - valid leaf, unverifiable chain → `... OK (chain verification failed)` / `Certificate is valid until …`
  - expired leaf → `... EXPIRED` / `Certificate was valid until …`
- `shellcheck` clean on the modified script and the new test.

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)
