### PR TITLE
test: fix flaky certs_standalone (wait for standalone conf removal)

### DIFF
--- a/test/tests/certs_standalone/run.sh
+++ b/test/tests/certs_standalone/run.sh
@@ -74,6 +74,8 @@ elif [[ "${DRY_RUN:-}" == 1 ]]; then
   echo "Domain ${domains[0]} is on certificate."
 fi
 
+# The standalone conf is removed once the certificate is issued; wait for that.
+wait_for_standalone_conf_rm "${domains[0]}" "$le_container_name"
 docker exec "$le_container_name" bash -c "[[ -f /etc/nginx/conf.d/standalone-cert-${domains[0]}.conf ]]" \
   && echo "Standalone configuration for ${domains[0]} wasn't correctly removed."
 
@@ -108,5 +110,6 @@ for domain in "${domains[1]}" "${domains[2]}"; do
   fi
 done
 
+wait_for_standalone_conf_rm "${domains[1]}" "$le_container_name"
 docker exec "$le_container_name" bash -c "[[ ! -f /etc/nginx/conf.d/standalone-cert-${domains[1]}.conf ]]" \
   || echo "Standalone configuration for ${domains[1]} wasn't correctly removed."

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -154,6 +154,25 @@ function wait_for_standalone_conf {
 }
 export -f wait_for_standalone_conf
 
+# Wait for the standalone conf of domain $1 to be removed inside container $2
+function wait_for_standalone_conf_rm {
+  local domain="${1:?}"
+  local name="${2:?}"
+  local timeout
+  timeout="$(date +%s)"
+  timeout="$((timeout + 120))"
+  until docker exec "$name" [ ! -f "/etc/nginx/conf.d/standalone-cert-$domain.conf" ]; do
+    if [[ "$(date +%s)" -gt "$timeout" ]]; then
+      echo "Standalone configuration file for $domain was not removed under one minute, timing out."
+      return 1
+    fi
+    sleep 0.1
+  done
+  [[ "${DRY_RUN:-}" == 1 ]] && echo "Standalone configuration for $domain has been removed."
+  return 0
+}
+export -f wait_for_standalone_conf_rm
+
 
 # Wait for the /etc/nginx/certs/$1.crt symlink to exist inside container $2
 function wait_for_symlink {


### PR DESCRIPTION
## What

Make the `certs_standalone` integration test reliable. It can fail intermittently in CI with:

```
Standalone configuration for <domain> wasn't correctly removed.
```

## Why

After a standalone certificate is issued, acme-companion removes the temporary standalone challenge config (`/etc/nginx/conf.d/standalone-cert-<domain>.conf`) and reloads nginx. The test waited for the **certificate symlink** to appear and then checked **immediately** that the standalone config was gone:

```bash
if wait_for_symlink "${domains[1]}" "$le_container_name"; then ... fi
...
docker exec ... "[[ ! -f .../standalone-cert-${domains[1]}.conf ]]" || echo "... wasn't correctly removed."
```

The config removal (and nginx reload) can lag slightly behind the symlink creation, so under CI load the check ran before the removal completed and the test failed — even though the removal happened a moment later. (There was a `wait_for_symlink` / `wait_for_symlink_rm` but no equivalent wait for the standalone conf removal.)

## How

- `test/tests/test-functions.sh` — add a `wait_for_standalone_conf_rm` helper (mirrors the existing `wait_for_symlink_rm`, 2-minute timeout).
- `test/tests/certs_standalone/run.sh` — wait for the standalone conf to be removed before asserting it is gone (for both the single-domain and SAN cases).

Test-only change; no product code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
