### PR TITLE
feat: replace LETSENCRYPT_HOST with ACME_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,17 +100,17 @@ Albeit **optional**, it is **recommended** to provide a valid default email addr
 
 ### Step 3 - proxied container(s)
 
-Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxied with environment variables `VIRTUAL_HOST` and `LETSENCRYPT_HOST` both set to the domain(s) your proxied container is going to use.
+Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxied with environment variables `VIRTUAL_HOST` and `ACME_HOST` both set to the domain(s) your proxied container is going to use.
 
-[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `LETSENCRYPT_HOST` control certificate creation and SSL enabling by **acme-companion**.
+[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `ACME_HOST` control certificate creation and SSL enabling by **acme-companion**.
 
-Certificates will only be issued for containers that have both `VIRTUAL_HOST` and `LETSENCRYPT_HOST` variables set to domain(s) that correctly resolve to the host, provided the host is publicly reachable.
+Certificates will only be issued for containers that have both `VIRTUAL_HOST` and `ACME_HOST` variables set to domain(s) that correctly resolve to the host, provided the host is publicly reachable.
 
 ```shell
 $ docker run --detach \
     --name your-proxied-app \
     --env "VIRTUAL_HOST=subdomain.yourdomain.tld" \
-    --env "LETSENCRYPT_HOST=subdomain.yourdomain.tld" \
+    --env "ACME_HOST=subdomain.yourdomain.tld" \
     nginx
 ```
 
@@ -125,7 +125,7 @@ $ docker run --detach \
     --name grafana \
     --env "VIRTUAL_HOST=othersubdomain.yourdomain.tld" \
     --env "VIRTUAL_PORT=3000" \
-    --env "LETSENCRYPT_HOST=othersubdomain.yourdomain.tld" \
+    --env "ACME_HOST=othersubdomain.yourdomain.tld" \
     --env "LETSENCRYPT_EMAIL=mail@yourdomain.tld" \
     grafana/grafana
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Albeit **optional**, it is **recommended** to provide a valid default email addr
 
 Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxied with environment variables `VIRTUAL_HOST` and `ACME_HOST` both set to the domain(s) your proxied container is going to use.
 
-[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `ACME_HOST` control certificate creation and SSL enabling by **acme-companion**.
+[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) controls proxying by **nginx-proxy** and `ACME_HOST` controls certificate creation and SSL enabling by **acme-companion**.
 
 Certificates will only be issued for containers that have both `VIRTUAL_HOST` and `ACME_HOST` variables set to domain(s) that correctly resolve to the host, provided the host is publicly reachable.
 

--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -62,6 +62,24 @@ function create_links {
     return $return_code
 }
 
+function get_hosts_array_var {
+    local cid="${1:?}"
+    local acme_var="ACME_${cid}_HOST"
+    if declare -p "$acme_var" > /dev/null 2>&1; then
+        echo "$acme_var"
+        return 0
+    fi
+
+    local letsencrypt_var="LETSENCRYPT_${cid}_HOST"
+    if declare -p "$letsencrypt_var" > /dev/null 2>&1; then
+        echo "$letsencrypt_var"
+        return 0
+    fi
+
+    echo "Warning: no host array found for ${cid} (expected ${acme_var} or ${letsencrypt_var})." >&2
+    return 1
+}
+
 function cleanup_links {
     local -a LETSENCRYPT_CONTAINERS
     local -a LETSENCRYPT_STANDALONE_CERTS
@@ -86,7 +104,9 @@ function cleanup_links {
     [[ -f /app/letsencrypt_user_data ]] && source /app/letsencrypt_user_data
     LETSENCRYPT_CONTAINERS+=( "${LETSENCRYPT_STANDALONE_CERTS[@]}" )
     for cid in "${LETSENCRYPT_CONTAINERS[@]}"; do
-      local -n hosts_array="LETSENCRYPT_${cid}_HOST"
+      local hosts_var
+      hosts_var="$(get_hosts_array_var "$cid")" || continue
+      local -n hosts_array="$hosts_var"
       for domain in "${hosts_array[@]}"; do
         domain="$(strip_wildcard "$domain")"
         # Add domain to the array storing currently enabled domains.
@@ -96,7 +116,7 @@ function cleanup_links {
     [[ "$DEBUG" == 1 ]] && echo "Enabled domains: ${ENABLED_DOMAINS[*]}"
 
     # Create an array containing only domains for which a symlinked private key exists
-    # in /etc/nginx/certs but that no longer have a corresponding LETSENCRYPT_HOST set
+    # in /etc/nginx/certs but that no longer have a corresponding ACME_HOST/LETSENCRYPT_HOST set
     # on an active container or on /app/letsencrypt_user_data
     if [[ ${#SYMLINKED_DOMAINS[@]} -gt 0 ]]; then
         mapfile -t DISABLED_DOMAINS < <(echo "${SYMLINKED_DOMAINS[@]}" \
@@ -138,7 +158,9 @@ function cleanup_links {
 
 function update_cert {
     local cid="${1:?}"
-    local -n hosts_array="LETSENCRYPT_${cid}_HOST"
+    local hosts_var
+    hosts_var="$(get_hosts_array_var "$cid")" || return 1
+    local -n hosts_array="$hosts_var"
     # First domain will be our base domain
     local base_domain="${hosts_array[0]}"
 
@@ -562,7 +584,9 @@ function update_certs {
     if [[ -f /app/letsencrypt_user_data ]]; then
         if source /app/letsencrypt_user_data; then
             for cid in "${LETSENCRYPT_STANDALONE_CERTS[@]}"; do
-                local -n hosts_array="LETSENCRYPT_${cid}_HOST"
+                local hosts_var
+                hosts_var="$(get_hosts_array_var "$cid")" || continue
+                local -n hosts_array="$hosts_var"
                 
                 local -n acme_challenge="ACME_${cid}_CHALLENGE"
                 acme_challenge="${acme_challenge:-HTTP-01}"

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -13,13 +13,17 @@
 LETSENCRYPT_CONTAINERS=(
 {{ $orderedContainers := sortObjectsByKeysDesc $ "Created" }}
 {{ range $_, $container := $orderedContainers }}
-    {{ $hosts := trim (coalesce $container.Env.ACME_HOST $container.Env.LETSENCRYPT_HOST "") }}
+    {{ $rawHosts := trim (coalesce $container.Env.ACME_HOST $container.Env.LETSENCRYPT_HOST "") }}
+    {{ $hosts := trimSuffix "," $rawHosts }}
     {{ if $hosts }}
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
             {{/* Explicit per-domain splitting of the certificate */}}
             {{ range $host := split $hosts "," }}
                 {{ $host := trim $host }}
-                {{- "\n\t" }}'{{ printf "%.12s" $container.ID }}_{{ sha1 $host }}' # {{ $container.Name }}, created at {{ $container.Created }}
+                {{ $host := trimSuffix "." $host }}
+                {{- if $host }}
+                    {{- "\n\t" }}'{{ printf "%.12s" $container.ID }}_{{ sha1 $host }}' # {{ $container.Name }}, created at {{ $container.Created }}
+                {{- end }}
             {{ end }}
         {{ else }}
             {{/* Default: multi-domain (SAN) certificate */}}
@@ -91,7 +95,9 @@ LETSENCRYPT_CONTAINERS=(
                     {{- range $host := split $hosts "," }}
                         {{- $host := trim $host }}
                         {{- $host := trimSuffix "." $host }}
-                        {{- "\n\t" }}'{{ $host }}'
+                        {{- if $host }}
+                            {{- "\n\t" }}'{{ $host }}'
+                        {{- end }}
                     {{- end }}
             {{- "\n" }})
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $KEYSIZE }}"

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -12,11 +12,12 @@
 
 LETSENCRYPT_CONTAINERS=(
 {{ $orderedContainers := sortObjectsByKeysDesc $ "Created" }}
-{{ range $_, $container := whereExist $orderedContainers "Env.LETSENCRYPT_HOST" }}
-    {{ if trim $container.Env.LETSENCRYPT_HOST }}
+{{ range $_, $container := $orderedContainers }}
+    {{ $hosts := trim (coalesce $container.Env.ACME_HOST $container.Env.LETSENCRYPT_HOST "") }}
+    {{ if $hosts }}
         {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
             {{/* Explicit per-domain splitting of the certificate */}}
-            {{ range $host := split $container.Env.LETSENCRYPT_HOST "," }}
+            {{ range $host := split $hosts "," }}
                 {{ $host := trim $host }}
                 {{- "\n\t" }}'{{ printf "%.12s" $container.ID }}_{{ sha1 $host }}' # {{ $container.Name }}, created at {{ $container.Created }}
             {{ end }}
@@ -28,9 +29,11 @@ LETSENCRYPT_CONTAINERS=(
 {{ end }}
 )
 
-{{ range $hosts, $containers := groupBy $ "Env.LETSENCRYPT_HOST" }}
-    {{ $hosts := trimSuffix "," $hosts }}
-    {{ range $container := $containers }}
+{{ range $_, $container := $orderedContainers }}
+    {{/* ACME_HOST is preferred, LETSENCRYPT_HOST kept for backward compatibility. */}}
+    {{ $rawHosts := trim (coalesce $container.Env.ACME_HOST $container.Env.LETSENCRYPT_HOST "") }}
+    {{ $hosts := trimSuffix "," $rawHosts }}
+    {{ if $hosts }}
         {{/* Trim spaces and set empty values on per-container environment variables */}}
         {{ $KEYSIZE := trim (coalesce $container.Env.LETSENCRYPT_KEYSIZE "") }}
         {{ $STAGING := trim (coalesce $container.Env.LETSENCRYPT_TEST "") }}
@@ -57,7 +60,7 @@ LETSENCRYPT_CONTAINERS=(
                 {{ $host := trim $host }}
                 {{ $host := trimSuffix "." $host }}
                 {{ $hostHash := sha1 $host }}
-                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_HOST=('{{ $host }}')
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_HOST=('{{ $host }}')
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_KEYSIZE="{{ $KEYSIZE }}"
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_TEST="{{ $STAGING }}"
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_EMAIL="{{ $EMAIL }}"
@@ -84,7 +87,7 @@ LETSENCRYPT_CONTAINERS=(
             {{ end }}
         {{ else }}
             {{/* Default: multi-domain (SAN) certificate */}}
-            {{- "\n" }}LETSENCRYPT_{{ $cid }}_HOST=( 
+            {{- "\n" }}ACME_{{ $cid }}_HOST=( 
                     {{- range $host := split $hosts "," }}
                         {{- $host := trim $host }}
                         {{- $host := trimSuffix "." $host }}

--- a/docs/Advanced-usage.md
+++ b/docs/Advanced-usage.md
@@ -63,7 +63,7 @@ $ docker run --detach \
     nginxproxy/acme-companion
 ```
 
-### Step 4 - proxyed container(s)
+### Step 4 - proxied container(s)
 
 * Once the three containers are up, start any containers to be proxied as described in [basic usage](./Basic-usage.md).
 

--- a/docs/Advanced-usage.md
+++ b/docs/Advanced-usage.md
@@ -71,7 +71,7 @@ $ docker run --detach \
 $ docker run --detach \
     --name your-proxyed-app \
     --env "VIRTUAL_HOST=subdomain.yourdomain.tld" \
-    --env "LETSENCRYPT_HOST=subdomain.yourdomain.tld" \
+    --env "ACME_HOST=subdomain.yourdomain.tld" \
     nginx
 ```
 

--- a/docs/Basic-usage.md
+++ b/docs/Basic-usage.md
@@ -48,17 +48,19 @@ Albeit **optional**, it is **recommended** to provide a valid default email addr
 
 ### Step 3 - proxyed container(s)
 
-Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxyed with environment variables `VIRTUAL_HOST` and `LETSENCRYPT_HOST` both set to the domain(s) your proxyed container is going to use. Multiple hosts can be separated using commas.
+Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxyed with environment variables `VIRTUAL_HOST` and `ACME_HOST` both set to the domain(s) your proxied container is going to use. Multiple hosts can be separated using commas.
 
-[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `LETSENCRYPT_HOST` control certificate creation and SSL enabling by **acme-companion**.
+[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `ACME_HOST` control certificate creation and SSL enabling by **acme-companion**.
 
-Certificates will only be issued for containers that have both `VIRTUAL_HOST` and `LETSENCRYPT_HOST` variables set to domain(s) that correctly resolve to the host, provided the host is publicly reachable.
+Certificates will only be issued for containers that have both `VIRTUAL_HOST` and `ACME_HOST` variables set to domain(s) that correctly resolve to the host, provided the host is publicly reachable.
+
+For backward compatibility, `LETSENCRYPT_HOST` is still supported as an alternative to `ACME_HOST`.
 
 ```shell
 $ docker run --detach \
     --name your-proxyed-app \
     --env "VIRTUAL_HOST=subdomain.yourdomain.tld" \
-    --env "LETSENCRYPT_HOST=subdomain.yourdomain.tld" \
+    --env "ACME_HOST=subdomain.yourdomain.tld" \
     nginx
 ```
 
@@ -73,7 +75,7 @@ $ docker run --detach \
     --name grafana \
     --env "VIRTUAL_HOST=othersubdomain.yourdomain.tld" \
     --env "VIRTUAL_PORT=3000" \
-    --env "LETSENCRYPT_HOST=othersubdomain.yourdomain.tld" \
+    --env "ACME_HOST=othersubdomain.yourdomain.tld" \
     --env "LETSENCRYPT_EMAIL=mail@yourdomain.tld" \
     grafana/grafana
 ```

--- a/docs/Basic-usage.md
+++ b/docs/Basic-usage.md
@@ -46,11 +46,11 @@ The host docker socket has to be bound inside this container too, this time to `
 
 Albeit **optional**, it is **recommended** to provide a valid default email address through the `DEFAULT_EMAIL` environment variable, so that Let's Encrypt can warn you about expiring certificates and allow you to recover your account.
 
-### Step 3 - proxyed container(s)
+### Step 3 - proxied container(s)
 
-Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxyed with environment variables `VIRTUAL_HOST` and `ACME_HOST` both set to the domain(s) your proxied container is going to use. Multiple hosts can be separated using commas.
+Once both **nginx-proxy** and **acme-companion** containers are up and running, start any container you want proxied with environment variables `VIRTUAL_HOST` and `ACME_HOST` both set to the domain(s) your proxied container is going to use. Multiple hosts can be separated using commas.
 
-[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) control proxying by **nginx-proxy** and `ACME_HOST` control certificate creation and SSL enabling by **acme-companion**.
+[`VIRTUAL_HOST`](https://github.com/nginx-proxy/nginx-proxy#usage) controls proxying by **nginx-proxy** and `ACME_HOST` controls certificate creation and SSL enabling by **acme-companion**.
 
 Certificates will only be issued for containers that have both `VIRTUAL_HOST` and `ACME_HOST` variables set to domain(s) that correctly resolve to the host, provided the host is publicly reachable.
 
@@ -66,7 +66,7 @@ $ docker run --detach \
 
 The containers being proxied must expose the port to be proxied, either by using the `EXPOSE` directive in their Dockerfile or by using the `--expose` flag to `docker run` or `docker create`.
 
-If the proxyed container listen on and expose another port than the default `80`, you can force **nginx-proxy** to use this port with the [`VIRTUAL_PORT`](https://github.com/nginx-proxy/nginx-proxy#multiple-ports) environment variable.
+If the proxied container listen on and expose another port than the default `80`, you can force **nginx-proxy** to use this port with the [`VIRTUAL_PORT`](https://github.com/nginx-proxy/nginx-proxy#multiple-ports) environment variable.
 
 Example using [Grafana](https://hub.docker.com/r/grafana/grafana/) (expose and listen on port 3000):
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -26,7 +26,7 @@ And on a proxied container (setting a per-container Pre-Hook):
 $ docker run --detach \
     --name your-proxyed-app \
     --env "VIRTUAL_HOST=yourdomain.tld" \
-    --env "LETSENCRYPT_HOST=yourdomain.tld" \
+    --env "ACME_HOST=yourdomain.tld" \
     --env "ACME_PRE_HOOK=echo 'start'" \
     nginx
 ```
@@ -51,7 +51,7 @@ And on a proxied container (setting a per-container Post-Hook):
 $ docker run --detach \
     --name your-proxyed-app \
     --env "VIRTUAL_HOST=yourdomain.tld" \
-    --env "LETSENCRYPT_HOST=yourdomain.tld" \
+    --env "ACME_HOST=yourdomain.tld" \
     --env "ACME_POST_HOOK=echo 'start'" \
     nginx
 ```

--- a/docs/Invalid-authorizations.md
+++ b/docs/Invalid-authorizations.md
@@ -48,9 +48,9 @@ Review [basic usage](./Basic-usage.md) or [advanced usage](./Advanced-usage.md),
 
 Pay special attention to the fact that the volumes **MUST** be shared between the different containers.
 
-#### you forgot to set both `VIRTUAL_HOST` and `LETSENCRYPT_HOST` on the proxyed container.
+#### you forgot to set both `VIRTUAL_HOST` and `ACME_HOST` on the proxied container.
 
-Both are required. Every domain on `LETSENCRYPT_HOST`**must** be on `VIRTUAL_HOST`too.
+Both are required. Every domain on `ACME_HOST`**must** be on `VIRTUAL_HOST`too.
 
 #### you are using an outdated version of either **acme-companion** or the nginx.tmpl file (if running a 3 containers setup)
 

--- a/docs/Invalid-authorizations.md
+++ b/docs/Invalid-authorizations.md
@@ -50,7 +50,7 @@ Pay special attention to the fact that the volumes **MUST** be shared between th
 
 #### you forgot to set both `VIRTUAL_HOST` and `ACME_HOST` on the proxied container.
 
-Both are required. Every domain on `ACME_HOST`**must** be on `VIRTUAL_HOST`too.
+Both are required. Every domain on `ACME_HOST` **must** be on `VIRTUAL_HOST` too.
 
 #### you are using an outdated version of either **acme-companion** or the nginx.tmpl file (if running a 3 containers setup)
 

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -10,7 +10,7 @@ As described on [basic usage](./Basic-usage.md), the `ACME_HOST` environment var
 
 The following environment variables are optional and parametrize the way the Let's Encrypt client works.
 
-### per proxyed container
+### per proxied container
 
 #### DNS-01 ACME challenge
 
@@ -85,7 +85,7 @@ Let's Encrypt has a limit of [100 domains per certificate](https://letsencrypt.o
 
 #### Separate certificate for each domain
 
-The example above will issue a single domain certificate for all the domains listed in the `ACME_HOST` environment variable. If you need to have a separate certificate for each of the domains, you can add set the `LETSENCRYPT_SINGLE_DOMAIN_CERTS` environment variable to `true`.
+The example above will issue a single domain certificate for all the domains listed in the `ACME_HOST` environment variable. If you need to have a separate certificate for each of the domains, you can set the `LETSENCRYPT_SINGLE_DOMAIN_CERTS` environment variable to `true`.
 
 Example:
 
@@ -149,7 +149,7 @@ The `ACME_RENEW_AFTER` environment variable can be set on an application contain
 
 #### Default contact address
 
-The `DEFAULT_EMAIL` variable must be a valid email and, when set on the **acme-companion** container, will be used as a fallback when no email address is provided using proxyed container's `LETSENCRYPT_EMAIL` environment variables. It is highly recommended to set this variable to a valid email address that you own.
+The `DEFAULT_EMAIL` variable must be a valid email and, when set on the **acme-companion** container, will be used as a fallback when no email address is provided using proxied container's `LETSENCRYPT_EMAIL` environment variables. It is highly recommended to set this variable to a valid email address that you own.
 
 #### Private key re-utilization
 

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -4,7 +4,9 @@
 
 **NOTE on IPv6**: If the domain or sub domain you want to issue certificate for has an AAAA record set, Let's Encrypt will favor challenge validation over IPv6. [There is an IPv6 to IPv4 fallback in place but Let's Encrypt can't guarantee it'll work in every possible case](https://github.com/letsencrypt/boulder/issues/2770#issuecomment-340489871), so bottom line is **if you are not sure of both your host and your host's Docker reachability over IPv6, do not advertise an AAAA record** or LE challenge validation might fail.
 
-As described on [basic usage](./Basic-usage.md), the `LETSENCRYPT_HOST` environment variables needs to be declared in each to-be-proxied application containers for which you want to enable SSL and create certificate. It most likely needs to be the same as the `VIRTUAL_HOST` variable and must resolve to your host (which has to be publicly reachable).
+As described on [basic usage](./Basic-usage.md), the `ACME_HOST` environment variable needs to be declared in each to-be-proxied application container(s) for which you want to enable SSL and create certificate. It most likely needs to be the same as the `VIRTUAL_HOST` variable and must resolve to your host (which has to be publicly reachable).
+
+`LETSENCRYPT_HOST` is still accepted as an alternative to `ACME_HOST` for backward compatibility reasons.
 
 The following environment variables are optional and parametrize the way the Let's Encrypt client works.
 
@@ -75,7 +77,7 @@ Example:
 $ docker run --detach \
     --name your-proxyed-app \
     --env "VIRTUAL_HOST=yourdomain.tld,www.yourdomain.tld,anotherdomain.tld" \
-    --env "LETSENCRYPT_HOST=yourdomain.tld,www.yourdomain.tld,anotherdomain.tld" \
+    --env "ACME_HOST=yourdomain.tld,www.yourdomain.tld,anotherdomain.tld" \
     nginx
 ```
 
@@ -83,7 +85,7 @@ Let's Encrypt has a limit of [100 domains per certificate](https://letsencrypt.o
 
 #### Separate certificate for each domain
 
-The example above will issue a single domain certificate for all the domains listed in the `LETSENCRYPT_HOST` environment variable. If you need to have a separate certificate for each of the domains, you can add set the `LETSENCRYPT_SINGLE_DOMAIN_CERTS` environment variable to `true`.
+The example above will issue a single domain certificate for all the domains listed in the `ACME_HOST` environment variable. If you need to have a separate certificate for each of the domains, you can add set the `LETSENCRYPT_SINGLE_DOMAIN_CERTS` environment variable to `true`.
 
 Example:
 
@@ -91,7 +93,7 @@ Example:
 $ docker run --detach \
     --name your-proxyed-app \
     --env "VIRTUAL_HOST=yourdomain.tld,www.yourdomain.tld,anotherdomain.tld" \
-    --env "LETSENCRYPT_HOST=yourdomain.tld,www.yourdomain.tld,anotherdomain.tld" \
+    --env "ACME_HOST=yourdomain.tld,www.yourdomain.tld,anotherdomain.tld" \
     --env "LETSENCRYPT_SINGLE_DOMAIN_CERTS=true" \
     nginx
 ```
@@ -132,7 +134,7 @@ The `ACME_CERT_PROFILE` environment variable is used to select a specific profil
 
 #### Container restart on cert renewal
 
-The `LETSENCRYPT_RESTART_CONTAINER` environment variable, when set to `true` on an application container, will restart this container whenever the corresponding cert (`LETSENCRYPT_HOST`) is renewed. This is useful when certificates are directly used inside a container for other purposes than HTTPS (e.g. an FTPS server), to make sure those containers always use an up to date certificate.
+The `LETSENCRYPT_RESTART_CONTAINER` environment variable, when set to `true` on an application container, will restart this container whenever the corresponding cert (`ACME_HOST`) is renewed. This is useful when certificates are directly used inside a container for other purposes than HTTPS (e.g. an FTPS server), to make sure those containers always use an up to date certificate.
 
 #### Pre-Hook and Post-Hook
 

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -31,24 +31,26 @@ The user configuration file is a collection of bash variables and array, and fol
 
 `LETSENCRYPT_STANDALONE_CERTS` : a bash array containing identifier(s) for you standalone certificate(s). Each element in the array has to be unique. Those identifiers are internal to the container process and won't ever be visible to the outside world or appear on your certificate.
 
-`LETSENCRYPT_uniqueidentifier_HOST` : a bash array containing domain(s) that will be covered by the certificate corresponding to `uniqueidentifier`.
+`ACME_uniqueidentifier_HOST` : a bash array containing domain(s) that will be covered by the certificate corresponding to `uniqueidentifier`.
 
-Each identifier in `LETSENCRYPT_STANDALONE_CERTS` must have its own corresponding `LETSENCRYPT_uniqueidentifier_HOST` array, where the string `uniqueidentifier` has to be identical to that identifier. 
+Each identifier in `LETSENCRYPT_STANDALONE_CERTS` must have its own corresponding `ACME_uniqueidentifier_HOST` array, where the string `uniqueidentifier` has to be identical to that identifier.
+
+For backward compatibility, `LETSENCRYPT_uniqueidentifier_HOST` is still supported as an alternative to `ACME_uniqueidentifier_HOST`.
 
 **Minimal example generating a single certificate for a single domain:**
 
 ```bash
 LETSENCRYPT_STANDALONE_CERTS=('uniqueidentifier')
-LETSENCRYPT_uniqueidentifier_HOST=('yourdomain.tld')
+ACME_uniqueidentifier_HOST=('yourdomain.tld')
 ```
 
 **Example with multiple certificates and domains:**
 
 ```bash
 LETSENCRYPT_STANDALONE_CERTS=('web' 'app' 'othersite')
-LETSENCRYPT_web_HOST=('yourdomain.tld' 'www.yourdomain.tld')
-LETSENCRYPT_app_HOST=('myapp.yourdomain.tld' 'myapp.yourotherdomain.tld' 'service.yourotherdomain.tld')
-LETSENCRYPT_othersite_HOST=('yetanotherdomain.tld')
+ACME_web_HOST=('yourdomain.tld' 'www.yourdomain.tld')
+ACME_app_HOST=('myapp.yourdomain.tld' 'myapp.yourotherdomain.tld' 'service.yourotherdomain.tld')
+ACME_othersite_HOST=('yetanotherdomain.tld')
 ```
 
 **Example using DNS-01 verification:**
@@ -57,9 +59,9 @@ In this example: `web` and `app` generate a certificate using the global/default
 
 ```bash
 LETSENCRYPT_STANDALONE_CERTS=('web' 'app' 'othersite')
-LETSENCRYPT_web_HOST=('yourdomain.tld' 'www.yourdomain.tld')
-LETSENCRYPT_app_HOST=('myapp.yourdomain.tld' 'myapp.yourotherdomain.tld' 'service.yourotherdomain.tld')
-LETSENCRYPT_othersite_HOST=('yetanotherdomain.tld')
+ACME_web_HOST=('yourdomain.tld' 'www.yourdomain.tld')
+ACME_app_HOST=('myapp.yourdomain.tld' 'myapp.yourotherdomain.tld' 'service.yourotherdomain.tld')
+ACME_othersite_HOST=('yetanotherdomain.tld')
 
 ACME_othersite_CHALLENGE=DNS-01
 declare -A ACMESH_othersite_DNS_API_CONFIG=(

--- a/test/tests/certs_san/run.sh
+++ b/test/tests/certs_san/run.sh
@@ -45,7 +45,7 @@ for hosts in "${letsencrypt_hosts[@]}"; do
   base_domain="$(get_base_domain "$hosts")"
   container="test$i"
 
-  # Run an Nginx container passing one of the comma separated list as LETSENCRYPT_HOST env var.
+  # Run an Nginx container passing one of the comma separated lists as ACME_HOST env var.
   run_nginx_container --hosts "$hosts" --name "$container"
 
   # Wait for a symlink at /etc/nginx/certs/$base_domain.crt

--- a/test/tests/certs_single/run.sh
+++ b/test/tests/certs_single/run.sh
@@ -27,7 +27,9 @@ trap cleanup EXIT
 
 # Run a separate nginx container for each domain in the $domains array.
 # Start all the containers in a row so that docker-gen debounce timers fire only once.
-for domain in "${domains[@]}"; do
+# Keep one container on legacy LETSENCRYPT_HOST to ensure backward compatibility.
+run_nginx_container --hosts "${domains[0]}" --legacy-host-var
+for domain in "${domains[@]:1}"; do
   run_nginx_container --hosts "$domain"
 done
 

--- a/test/tests/certs_single_domain/run.sh
+++ b/test/tests/certs_single_domain/run.sh
@@ -41,7 +41,7 @@ for hosts in "${letsencrypt_hosts[@]}"; do
 
   container="test$i"
 
-  # Run an Nginx container passing one of the comma separated list as LETSENCRYPT_HOST env var.
+  # Run an Nginx container passing one of the comma separated lists as ACME_HOST env var.
   run_nginx_container --hosts "${hosts}" --name "$container" --cli-args "--env LETSENCRYPT_SINGLE_DOMAIN_CERTS=true"
 
   for domain in "${domains[@]}"; do

--- a/test/tests/certs_standalone/run.sh
+++ b/test/tests/certs_standalone/run.sh
@@ -35,7 +35,8 @@ function cleanup {
 }
 trap cleanup EXIT
 
-# Create letsencrypt_user_data with a single domain cert
+# Create letsencrypt_user_data with a single domain cert using the legacy host array
+# to verify backward compatibility shim support.
 cat > "${GITHUB_WORKSPACE}/test/tests/certs_standalone/letsencrypt_user_data" <<EOF
 LETSENCRYPT_STANDALONE_CERTS=('single')
 LETSENCRYPT_single_HOST=('${domains[0]}')
@@ -79,11 +80,12 @@ wait_for_standalone_conf_rm "${domains[0]}" "$le_container_name"
 docker exec "$le_container_name" bash -c "[[ -f /etc/nginx/conf.d/standalone-cert-${domains[0]}.conf ]]" \
   && echo "Standalone configuration for ${domains[0]} wasn't correctly removed."
 
-# Add another (SAN) certificate to letsencrypt_user_data
+# Add another (SAN) certificate to letsencrypt_user_data and switch host arrays
+# to ACME_*_HOST to verify the new internal format.
 cat > "${GITHUB_WORKSPACE}/test/tests/certs_standalone/letsencrypt_user_data" <<EOF
 LETSENCRYPT_STANDALONE_CERTS=('single' 'san')
-LETSENCRYPT_single_HOST=('${domains[0]}')
-LETSENCRYPT_san_HOST=('${domains[1]}' '${domains[2]}')
+ACME_single_HOST=('${domains[0]}')
+ACME_san_HOST=('${domains[1]}' '${domains[2]}')
 EOF
 
 # Manually trigger the service loop

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -78,6 +78,7 @@ export -f run_le_container
 # Run an nginx container
 function run_nginx_container {
   local -a cli_args_arr
+  local host_env_var="ACME_HOST"
 
   while [[ $# -gt 0 ]]; do
   local flag="$1"
@@ -87,6 +88,11 @@ function run_nginx_container {
       local le_host="${2:?}"
       local virtual_host="${le_host// /}"; virtual_host="${virtual_host//.,/,}"; virtual_host="${virtual_host%,}"
       shift 2
+      ;;
+
+      --legacy-host-var)
+      host_env_var="LETSENCRYPT_HOST"
+      shift
       ;;
 
       -n|--name)
@@ -116,19 +122,19 @@ function run_nginx_container {
     return 1
   fi
 
-  [[ "${DRY_RUN:-}" == 1 ]] && echo "Starting $container_name nginx container, with VIRTUAL_HOST=$virtual_host, LETSENCRYPT_HOST=$le_host and the following cli arguments : ${cli_args_arr[*]}."
+  [[ "${DRY_RUN:-}" == 1 ]] && echo "Starting $container_name nginx container, with VIRTUAL_HOST=$virtual_host, ${host_env_var}=$le_host and the following cli arguments : ${cli_args_arr[*]}."
   
   if docker run --rm -d \
     --name "${container_name:-$virtual_host}" \
     -e "VIRTUAL_HOST=$virtual_host" \
-    -e "LETSENCRYPT_HOST=$le_host" \
+    -e "${host_env_var}=$le_host" \
     --label com.github.nginx-proxy.acme-companion.test-suite \
     "${cli_args_arr[@]}" \
     nginx:alpine > /dev/null ; \
   then
     [[ "${DRY_RUN:-}" == 1 ]] && echo "Started $container_name nginx container."
   else
-    echo "Failed to start $container_name nginx container, with VIRTUAL_HOST=$virtual_host, LETSENCRYPT_HOST=$le_host and the following cli arguments : ${cli_args_arr[*]}."
+    echo "Failed to start $container_name nginx container, with VIRTUAL_HOST=$virtual_host, ${host_env_var}=$le_host and the following cli arguments : ${cli_args_arr[*]}."
     return 1
   fi
   return 0


### PR DESCRIPTION
This is not exactly a **new** feature per se.

Some of the environment variables and internal variables that **acme-companion** use are still prefixed with `LETSENCRYPT_` despite the fact that this project aim to be usable with any CA that implement the ACME protocol.

This is a leftover from the beginning of this project when it was still named **letsencrypt-nginx-proxy-companion** and Let's Encrypt was the only existing CA that offered ACME certificate issuance.

I intend to gradually change those `LETSENCRYPT_` prefixes to `ACME_` (while keeping backward compatibility) to clarify the fact that this project is not meant to be used exclusively with Let's Encrypt.