### PR TITLE
test: fix renew_private_keys repeated failure

### DIFF
--- a/test/tests/renew_private_keys/run.sh
+++ b/test/tests/renew_private_keys/run.sh
@@ -39,29 +39,31 @@ function key_fingerprint {
 # Run an nginx container that opts out of private key renewal for its certificate.
 run_nginx_container --hosts "$domain" --cli-args "--env ACME_RENEW_PRIVATE_KEYS=false"
 
-# Wait for issuance, then record the initial key fingerprint and expiration date.
+# Wait for issuance, then record the initial key fingerprint and certificate serial.
 wait_for_symlink "$domain" "$le_container_name"
 first_key="$(key_fingerprint)" || echo "Could not read the initial private key for $domain."
-first_cert_expire="$(get_cert_date_epoch expiration "$domain" "$le_container_name")"
+first_serial="$(get_cert_serial "$domain" "$le_container_name")"
 
 # Just to be sure
 sleep 5
 
 # Issue a forced renewal and poll until the certificate is actually renewed.
-docker exec "$le_container_name" /app/force_renew &> /dev/null
+renew_output="$(docker exec "$le_container_name" /app/force_renew 2>&1)"
 timeout=$(($(date +%s) + 60))
-second_cert_expire="$first_cert_expire"
+second_serial="$first_serial"
 while [[ $(date +%s) -lt $timeout ]]; do
-  new_expire="$(get_cert_date_epoch expiration "$domain" "$le_container_name" 2>/dev/null || echo "$first_cert_expire")"
-  if [[ "$new_expire" =~ ^[0-9]+$ ]] && [[ $new_expire -gt $first_cert_expire ]]; then
-    second_cert_expire="$new_expire"
+  new_serial="$(get_cert_serial "$domain" "$le_container_name" 2>/dev/null || true)"
+  if [[ -n "$new_serial" && "$new_serial" != "$first_serial" ]]; then
+    second_serial="$new_serial"
     break
   fi
   sleep 2
 done
 
-if ! [[ $second_cert_expire -gt $first_cert_expire ]]; then
-  echo "Certificate for $domain was not renewed within 30s, cannot verify key reuse."
+if [[ "$second_serial" == "$first_serial" ]]; then
+  echo "Certificate for $domain was not renewed within 60s (serial unchanged: $first_serial), cannot verify key reuse."
+  echo "force_renew output:"
+  echo "$renew_output"
 fi
 
 # With ACME_RENEW_PRIVATE_KEYS=false the private key must be unchanged after renewal.


### PR DESCRIPTION
This PR attempts to fix the `renew_private_keys` test that has been failing repeatedly since #1274 by reproducing the solution implemented in `test/tests/force_renew/run.sh` (ie checking that the certificate serial changes rather than checking that the expiration timestamp changes).