### PR TITLE
feat: replace LETSENCRYPT_KEYSIZE with ACME_KEYSIZE

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -279,7 +279,9 @@ function update_cert {
         return 1
     fi
 
-    local -n cert_keysize="LETSENCRYPT_${cid}_KEYSIZE"
+    local -n legacy_cert_keysize="LETSENCRYPT_${cid}_KEYSIZE"
+    local -n cert_keysize="ACME_${cid}_KEYSIZE"
+    cert_keysize="${cert_keysize:-${legacy_cert_keysize}}"
     if [[ -z "$cert_keysize" ]] || \
         [[ ! "$cert_keysize" =~ ^('2048'|'3072'|'4096'|'8192'|'ec-256'|'ec-384'|'ec-521')$ ]]; then
         cert_keysize=$DEFAULT_KEY_SIZE

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -39,7 +39,7 @@ LETSENCRYPT_CONTAINERS=(
     {{ $hosts := trimSuffix "," $rawHosts }}
     {{ if $hosts }}
         {{/* Trim spaces and set empty values on per-container environment variables */}}
-        {{ $KEYSIZE := trim (coalesce $container.Env.LETSENCRYPT_KEYSIZE "") }}
+        {{ $KEYSIZE := trim (coalesce $container.Env.ACME_KEYSIZE $container.Env.LETSENCRYPT_KEYSIZE "") }}
         {{ $STAGING := trim (coalesce $container.Env.LETSENCRYPT_TEST "") }}
         {{ $EMAIL := trim (coalesce $container.Env.LETSENCRYPT_EMAIL "") }}
         {{ $CA_URI := trim (coalesce $container.Env.ACME_CA_URI "") }}
@@ -65,7 +65,7 @@ LETSENCRYPT_CONTAINERS=(
                 {{ $host := trimSuffix "." $host }}
                 {{ $hostHash := sha1 $host }}
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_HOST=('{{ $host }}')
-                {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_KEYSIZE="{{ $KEYSIZE }}"
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_KEYSIZE="{{ $KEYSIZE }}"
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_TEST="{{ $STAGING }}"
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_EMAIL="{{ $EMAIL }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_CA_URI="{{ $CA_URI }}"
@@ -100,7 +100,7 @@ LETSENCRYPT_CONTAINERS=(
                         {{- end }}
                     {{- end }}
             {{- "\n" }})
-            {{- "\n" }}LETSENCRYPT_{{ $cid }}_KEYSIZE="{{ $KEYSIZE }}"
+            {{- "\n" }}ACME_{{ $cid }}_KEYSIZE="{{ $KEYSIZE }}"
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_TEST="{{ $STAGING }}"
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_EMAIL="{{ $EMAIL }}"
             {{- "\n" }}ACME_{{ $cid }}_CA_URI="{{ $CA_URI }}"

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -107,7 +107,7 @@ The `LETSENCRYPT_EMAIL` environment variable must be a valid email and can be us
 
 #### Private key size
 
-The `LETSENCRYPT_KEYSIZE` environment variable determines the type and size of the requested key. Supported values are `2048`, `3072`, `4096` or `8192` for RSA keys, and `ec-256`, `ec-384` or `ec-521` for elliptic curve keys. The default is RSA 4096.  
+The `ACME_KEYSIZE` environment variable determines the type and size of the requested key. Supported values are `2048`, `3072`, `4096` or `8192` for RSA keys, and `ec-256`, `ec-384` or `ec-521` for elliptic curve keys. The default is RSA 4096.  
 To change the global default set the `DEFAULT_KEY_SIZE` environment variable on the **acme-companion** container to one of the supported values specified above.
 
 #### OCSP stapling

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -78,7 +78,7 @@ Single bash variables:
 
 `LETSENCRYPT_uniqueidentifier_EMAIL` : must be a valid email and will be used by Let's Encrypt to warn you of impeding certificate expiration (should the automated renewal fail).
 
-`LETSENCRYPT_uniqueidentifier_KEYSIZE` : determines the size of the requested private key. See [private key size](./Let's-Encrypt-and-ACME.md#private-key-size) for accepted values.
+`ACME_uniqueidentifier_KEYSIZE` : determines the size of the requested private key. See [private key size](./Let's-Encrypt-and-ACME.md#private-key-size) for accepted values.
 
 `LETSENCRYPT_uniqueidentifier_TEST` : if set to true, the corresponding certificate will be a test certificates: it won't have the 5 certs/week/domain limits and will be signed by an untrusted intermediate (ie it won't be trusted by browsers).
 

--- a/test/tests/private_keys/run.sh
+++ b/test/tests/private_keys/run.sh
@@ -39,20 +39,25 @@ key_types=( \
 for key in "${!key_types[@]}"; do
 
   # Run an Nginx container with the wanted key type.
-  run_nginx_container --hosts "${domains[0]}" --name "${key}" --cli-args "--env LETSENCRYPT_KEYSIZE=${key}"
+  run_nginx_container --hosts "${domains[0]}" --name "${key}" --cli-args "--env ACME_KEYSIZE=${key}"
+
+  # Run an Nginx container with the wanted key type and the legacy environment variable name.
+  run_nginx_container --hosts "${domains[1]}" --name "${key}-legacy" --cli-args "--env LETSENCRYPT_KEYSIZE=${key}"
 
   # Grep the expected string from the public key in text form.
-  if wait_for_symlink "${domains[0]}" "$le_container_name"; then
-    public_key=$(docker exec "$le_container_name" openssl pkey -in "/etc/nginx/certs/${domains[0]}.key" -noout -text_pub)
-    if ! grep -q "${key_types[$key]}" <<< "$public_key"; then
-      echo "Keys for test $key were not of the correct type, expected ${key_types[$key]} and got the following:"
-      echo "$public_key"
+  for domain in "${domains[@]:0:2}"; do
+    if wait_for_symlink "$domain" "$le_container_name"; then
+      public_key=$(docker exec "$le_container_name" openssl pkey -in "/etc/nginx/certs/${domain}.key" -noout -text_pub)
+      if ! grep -q "${key_types[$key]}" <<< "$public_key"; then
+        echo "Private key for test $key and domain $domain was not of the correct type, expected ${key_types[$key]} and got the following:"
+        echo "$public_key"
+      fi
+    else
+      echo "${key_types[$key]} key test timed out for domain $domain"
     fi
-  else
-    echo "${key_types[$key]} key test timed out"
-  fi
+  done
 
-  docker stop "${key}" &> /dev/null
+  docker stop "${key}" "${key}-legacy" &> /dev/null
   docker exec "$le_container_name" /app/cleanup_test_artifacts
 
 done


### PR DESCRIPTION
Continuation of #1278

> Some of the environment variables and internal variables that acme-companion use are still prefixed with `LETSENCRYPT_` despite the fact that this project aim to be usable with any CA that implement the ACME protocol.
> 
> This is a leftover from the beginning of this project when it was still named **letsencrypt-nginx-proxy-companion** and Let's Encrypt was the only existing CA that offered ACME certificate issuance.
> 
> I intend to gradually change those `LETSENCRYPT_` prefixes to `ACME_` (while keeping backward compatibility) to clarify the fact that this project is not meant to be used exclusively with Let's Encrypt.