### PR TITLE
feat: replace LETSENCRYPT_SINGLE_DOMAIN_CERTS with ACME_SINGLE_DOMAIN_CERTS

### DIFF
--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -16,7 +16,7 @@ LETSENCRYPT_CONTAINERS=(
     {{ $rawHosts := trim (coalesce $container.Env.ACME_HOST $container.Env.LETSENCRYPT_HOST "") }}
     {{ $hosts := trimSuffix "," $rawHosts }}
     {{ if $hosts }}
-        {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
+        {{ if parseBool (coalesce $container.Env.ACME_SINGLE_DOMAIN_CERTS $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
             {{/* Explicit per-domain splitting of the certificate */}}
             {{ range $host := split $hosts "," }}
                 {{ $host := trim $host }}
@@ -58,7 +58,7 @@ LETSENCRYPT_CONTAINERS=(
         {{ $RENEW_PRIVATE_KEYS := trim (coalesce $container.Env.ACME_RENEW_PRIVATE_KEYS "") }}
         {{ $cid := printf "%.12s" $container.ID }}
         {{- "\n" }}# Container {{ $cid }} ({{ $container.Name }})
-        {{ if parseBool (coalesce $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
+        {{ if parseBool (coalesce $container.Env.ACME_SINGLE_DOMAIN_CERTS $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
             {{/* Explicit per-domain splitting of the certificate */}}
             {{ range $host := split $hosts "," }}
                 {{ $host := trim $host }}

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -85,7 +85,7 @@ Let's Encrypt has a limit of [100 domains per certificate](https://letsencrypt.o
 
 #### Separate certificate for each domain
 
-The example above will issue a single domain certificate for all the domains listed in the `ACME_HOST` environment variable. If you need to have a separate certificate for each of the domains, you can set the `LETSENCRYPT_SINGLE_DOMAIN_CERTS` environment variable to `true`.
+The example above will issue a single domain certificate for all the domains listed in the `ACME_HOST` environment variable. If you need to have a separate certificate for each of the domains, you can set the `ACME_SINGLE_DOMAIN_CERTS` environment variable to `true`.
 
 Example:
 
@@ -94,7 +94,7 @@ $ docker run --detach \
     --name your-proxyed-app \
     --env "VIRTUAL_HOST=yourdomain.tld,www.yourdomain.tld,anotherdomain.tld" \
     --env "ACME_HOST=yourdomain.tld,www.yourdomain.tld,anotherdomain.tld" \
-    --env "LETSENCRYPT_SINGLE_DOMAIN_CERTS=true" \
+    --env "ACME_SINGLE_DOMAIN_CERTS=true" \
     nginx
 ```
 

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -76,7 +76,7 @@ declare -A ACMESH_othersite_DNS_API_CONFIG=(
 
 Single bash variables:
 
-`LETSENCRYPT_uniqueidentifier_EMAIL` : must be a valid email and will be used by Let's Encrypt to warn you of impeding certificate expiration (should the automated renewal fail).
+`ACME_uniqueidentifier_EMAIL` : must be a valid email and will be used by Let's Encrypt to warn you of impeding certificate expiration (should the automated renewal fail).
 
 `ACME_uniqueidentifier_KEYSIZE` : determines the size of the requested private key. See [private key size](./Let's-Encrypt-and-ACME.md#private-key-size) for accepted values.
 

--- a/test/tests/certs_single_domain/run.sh
+++ b/test/tests/certs_single_domain/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-## Test for spliting SAN certificates into single domain certificates by NGINX container env variables
+## Test for splitting SAN certificates into single domain certificates by NGINX container env variables
+## Tests both ACME_SINGLE_DOMAIN_CERTS (current) and LETSENCRYPT_SINGLE_DOMAIN_CERTS (legacy) env vars.
 
 if [[ -z $GITHUB_ACTIONS ]]; then
   le_container_name="$(basename "${0%/*}")_$(date "+%Y-%m-%d_%H.%M.%S")"
@@ -35,14 +36,22 @@ letsencrypt_hosts=( \
   [1]="${domains[1]}, ${domains[2]}, ${domains[0]}" \   #comma separated list with spaces
   [2]="${domains[2]}, ${domains[0]}, ${domains[1]}," )  #comma separated list with spaces and a trailing comma
 
+# Alternate between the current and legacy single domain certs env var to test both.
+single_domain_env_vars=( \
+  [0]="ACME_SINGLE_DOMAIN_CERTS" \
+  [1]="LETSENCRYPT_SINGLE_DOMAIN_CERTS" \
+  [2]="ACME_SINGLE_DOMAIN_CERTS" )
+
 i=1
 
 for hosts in "${letsencrypt_hosts[@]}"; do
 
   container="test$i"
+  single_domain_env_var="${single_domain_env_vars[$((i - 1))]}"
 
-  # Run an Nginx container passing one of the comma separated lists as ACME_HOST env var.
-  run_nginx_container --hosts "${hosts}" --name "$container" --cli-args "--env LETSENCRYPT_SINGLE_DOMAIN_CERTS=true"
+  # Run an Nginx container passing one of the comma separated lists as ACME_HOST env var,
+  # alternating between ACME_SINGLE_DOMAIN_CERTS and LETSENCRYPT_SINGLE_DOMAIN_CERTS.
+  run_nginx_container --hosts "${hosts}" --name "$container" --cli-args "--env ${single_domain_env_var}=true"
 
   for domain in "${domains[@]}"; do
       ## For all the domains in the $domains array ...


### PR DESCRIPTION
Continuation of #1278, #1280, #1281 and #1282

> Some of the environment variables and internal variables that acme-companion use are still prefixed with `LETSENCRYPT_` despite the fact that this project aim to be usable with any CA that implement the ACME protocol.
> 
> This is a leftover from the beginning of this project when it was still named **letsencrypt-nginx-proxy-companion** and Let's Encrypt was the only existing CA that offered ACME certificate issuance.
> 
> I intend to gradually change those `LETSENCRYPT_` prefixes to `ACME_` (while keeping backward compatibility) to clarify the fact that this project is not meant to be used exclusively with Let's Encrypt.