### PR TITLE
refactor: replace LETSENCRYPT_CONTAINERS with ACME_CONTAINERS

### DIFF
--- a/app/letsencrypt_service
+++ b/app/letsencrypt_service
@@ -81,7 +81,7 @@ function get_hosts_array_var {
 }
 
 function cleanup_links {
-    local -a LETSENCRYPT_CONTAINERS
+    local -a ACME_CONTAINERS
     local -a ACME_STANDALONE_CERTS
     local -a LETSENCRYPT_STANDALONE_CERTS
     local -a ENABLED_DOMAINS
@@ -106,9 +106,9 @@ function cleanup_links {
 
     # Backward compatibility: fall back to LETSENCRYPT_STANDALONE_CERTS if ACME_STANDALONE_CERTS is unset
     [[ ${#ACME_STANDALONE_CERTS[@]} -eq 0 ]] && ACME_STANDALONE_CERTS=( "${LETSENCRYPT_STANDALONE_CERTS[@]}" )
-    LETSENCRYPT_CONTAINERS+=( "${ACME_STANDALONE_CERTS[@]}" )
+    ACME_CONTAINERS+=( "${ACME_STANDALONE_CERTS[@]}" )
 
-    for cid in "${LETSENCRYPT_CONTAINERS[@]}"; do
+    for cid in "${ACME_CONTAINERS[@]}"; do
       local hosts_var
       hosts_var="$(get_hosts_array_var "$cid")" || continue
       local -n hosts_array="$hosts_var"
@@ -578,7 +578,7 @@ function update_cert {
 }
 
 function update_certs {
-    local -a LETSENCRYPT_CONTAINERS
+    local -a ACME_CONTAINERS
     local -a ACME_STANDALONE_CERTS
     local -a LETSENCRYPT_STANDALONE_CERTS
 
@@ -614,14 +614,14 @@ function update_certs {
             done
 
             reload_nginx
-            LETSENCRYPT_CONTAINERS+=( "${ACME_STANDALONE_CERTS[@]}" )
+            ACME_CONTAINERS+=( "${ACME_STANDALONE_CERTS[@]}" )
         else
             echo "Warning: could not source /app/letsencrypt_user_data, skipping user data"
         fi
     fi
 
     should_reload_nginx='false'
-    for cid in "${LETSENCRYPT_CONTAINERS[@]}"; do
+    for cid in "${ACME_CONTAINERS[@]}"; do
         # Pass the eventual --force-renew arg to update_cert() as second arg
         update_cert "$cid" "${1:-}"
     done

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -10,7 +10,7 @@
 {{- end }}
 
 
-LETSENCRYPT_CONTAINERS=(
+ACME_CONTAINERS=(
 {{ $orderedContainers := sortObjectsByKeysDesc $ "Created" }}
 {{ range $_, $container := $orderedContainers }}
     {{ $rawHosts := trim (coalesce $container.Env.ACME_HOST $container.Env.LETSENCRYPT_HOST "") }}


### PR DESCRIPTION
Continuation of #1278, #1280, #1281, #1282, #1283 and #1284, and last PR on this topic.

This last change is internal only.

> Some of the environment variables and internal variables that acme-companion use are still prefixed with `LETSENCRYPT_` despite the fact that this project aim to be usable with any CA that implement the ACME protocol.
> 
> This is a leftover from the beginning of this project when it was still named **letsencrypt-nginx-proxy-companion** and Let's Encrypt was the only existing CA that offered ACME certificate issuance.
> 
> I intend to gradually change those `LETSENCRYPT_` prefixes to `ACME_` (while keeping backward compatibility) to clarify the fact that this project is not meant to be used exclusively with Let's Encrypt.