### PR TITLE
test: poll until nginx serves the expected certificate

### DIFF
--- a/test/tests/certs_san/run.sh
+++ b/test/tests/certs_san/run.sh
@@ -68,16 +68,10 @@ for hosts in "${letsencrypt_hosts[@]}"; do
       echo "$domain is on certificate."
     fi
 
-    # Wait for a connection to https://domain then grab the served certificate in text form.
-    wait_for_conn --domain "$domain"
-    served_cert_fingerprint="$(echo \
-      | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \
-      | openssl x509 -fingerprint -noout)"
-
-
-    # Compare the cert on file and what we got from the https connection.
-    # If not identical, display a full diff.
-    if [ "$created_cert_fingerprint" != "$served_cert_fingerprint" ]; then
+    # Wait for a connection to https://domain and for the served
+    # certificate to match the created certificate.
+    # If it does not, display a full diff.
+    if ! wait_for_conn --domain "$domain" --cert-match "$created_cert_fingerprint"; then
       echo "Nginx served an incorrect certificate for $domain."
       served_cert="$(echo \
         | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \

--- a/test/tests/certs_single/run.sh
+++ b/test/tests/certs_single/run.sh
@@ -53,15 +53,10 @@ for domain in "${domains[@]}"; do
     echo "Domain $domain is on certificate."
   fi
 
-  # Wait for a connection to https://domain then grab the served certificate fingerprint.
-  wait_for_conn --domain "$domain"
-  served_cert_fingerprint="$(echo \
-    | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \
-    | openssl x509 -fingerprint -noout)"
-
-  # Compare fingerprints from the cert on file and what we got from the https connection.
-  # If not identical, display a full diff.
-  if [ "$created_cert_fingerprint" != "$served_cert_fingerprint" ]; then
+  # Wait for a connection to https://domain and for the served
+  # certificate to match the created certificate.
+  # If it does not, display a full diff.
+  if ! wait_for_conn --domain "$domain" --cert-match "$created_cert_fingerprint"; then
     echo "Nginx served an incorrect certificate for $domain."
     served_cert="$(echo \
       | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \

--- a/test/tests/certs_single_domain/run.sh
+++ b/test/tests/certs_single_domain/run.sh
@@ -83,16 +83,10 @@ for hosts in "${letsencrypt_hosts[@]}"; do
       echo "$domain did not appear on certificate."
     fi
 
-    # Wait for a connection to https://domain then grab the served certificate in text form.
-    wait_for_conn --domain "$domain"
-    served_cert_fingerprint="$(echo \
-      | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \
-      | openssl x509 -fingerprint -noout)"
-
-
-    # Compare the cert on file and what we got from the https connection.
-    # If not identical, display a full diff.
-    if [ "$created_cert_fingerprint" != "$served_cert_fingerprint" ]; then
+    # Wait for a connection to https://domain and for the served
+    # certificate to match the created certificate.
+    # If it does not, display a full diff.
+    if ! wait_for_conn --domain "$domain" --cert-match "$created_cert_fingerprint"; then
       echo "Nginx served an incorrect certificate for $domain."
       served_cert="$(echo \
         | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -291,7 +291,7 @@ export -f check_cert_subj
 # If domain can't be reached return 1
 function check_cert_fingerprint {
   while [[ $# -gt 0 ]]; do
-  local flag="$1"
+    local flag="$1"
 
     case $flag in
       -d|--domain)

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -313,9 +313,13 @@ function check_cert_fingerprint {
   done
 
   local served_fingerprint
-  served_fingerprint="$(echo \
-    | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \
-    | openssl x509 -fingerprint -noout 2>/dev/null)"
+  if curl -k https://"$domain" &> /dev/null; then
+    served_fingerprint="$(echo \
+      | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \
+      | openssl x509 -fingerprint -noout 2>/dev/null)"
+  else
+    return 1
+  fi
 
   [[ -n "$served_fingerprint" && "$served_fingerprint" == "$expected_fingerprint" ]]
 }

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -286,13 +286,51 @@ function check_cert_subj {
 export -f check_cert_subj
 
 
+# Attempt to grab the certificate from domain passed with -d/--domain
+# then check if its fingerprint matches the one passed with -f/--fingerprint
+# If domain can't be reached return 1
+function check_cert_fingerprint {
+  while [[ $# -gt 0 ]]; do
+  local flag="$1"
+
+    case $flag in
+      -d|--domain)
+      local domain="${2:?}"
+      shift
+      shift
+      ;;
+
+      -f|--fingerprint)
+      local expected_fingerprint="${2:?}"
+      shift
+      shift
+      ;;
+
+      *) #Unknown option
+      shift
+      ;;
+    esac
+  done
+
+  local served_fingerprint
+  served_fingerprint="$(echo \
+    | openssl s_client -showcerts -servername "$domain" -connect "$domain:443" 2>/dev/null \
+    | openssl x509 -fingerprint -noout 2>/dev/null)"
+
+  [[ -n "$served_fingerprint" && "$served_fingerprint" == "$expected_fingerprint" ]]
+}
+export -f check_cert_fingerprint
+
+
 # Wait for a successful https connection to domain passed with -d/--domain then wait
 #   - until the served certificate isn't the default one (default behavior)
 #   - until the served certificate subject match a string (--subject-match)
+#   - until the served certificate fingerprint match a string (--cert-match)
 function wait_for_conn {
   local action
   local domain
   local string
+  local fingerprint
 
   while [[ $# -gt 0 ]]; do
   local flag="$1"
@@ -311,6 +349,12 @@ function wait_for_conn {
       shift
       ;;
 
+      --cert-match)
+      fingerprint="${2:?}"
+      shift
+      shift
+      ;;
+
       *) #Unknown option
       shift
       ;;
@@ -322,6 +366,18 @@ function wait_for_conn {
   timeout="$((timeout + 120))"
   action="${action:---no-match}"
   string="${string:-letsencrypt-nginx-proxy-companion}"
+
+  if [[ -n "${fingerprint:-}" ]]; then
+    until check_cert_fingerprint --domain "$domain" --fingerprint "$fingerprint"; do
+      if [[ "$(date +%s)" -gt "$timeout" ]]; then
+        echo "The certificate served by $domain did not match the expected certificate under two minutes, timing out."
+        return 1
+      fi
+      sleep 0.1
+    done
+    [[ "${DRY_RUN:-}" == 1 ]] && echo "Connection to $domain using https was successful."
+    return 0
+  fi
 
   until check_cert_subj --domain "$domain" "$action" "$string"; do
     if [[ "$(date +%s)" -gt "$timeout" ]]; then


### PR DESCRIPTION
The `certs_single`, `certs_san` and `certs_single_domain` tests grab the served certificate exactly once after `wait_for_conn` and fail on any mismatch. Since nginx reloads are asynchronous, that single grab can hit a reload window and come back empty, producing spurious failures like [this one](https://github.com/nginx-proxy/acme-companion/actions/runs/29166952468/job/86581632134) (`Nginx served an incorrect certificate for le1.wtf.` right after two `Could not read certificate from <stdin>` errors).

This adds a `--cert-match` option to `wait_for_conn` that polls until the served certificate fingerprint matches the expected one, within the existing two minutes timeout, and uses it in those three tests. The failure message and diff are only printed once the timeout expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)