### PR TITLE
feat: standalone certificates for containers without VIRTUAL_HOST

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
             certs_san,
             certs_single_domain,
             certs_standalone,
+            standalone_container,
             certs_renew_after,
             certs_default_renew_deprecated,
             cert_profiles,

--- a/app/letsencrypt_service.sh
+++ b/app/letsencrypt_service.sh
@@ -582,6 +582,7 @@ function update_cert {
 
 function update_certs {
     local -a ACME_CONTAINERS
+    local -a ACME_STANDALONE_CONTAINERS
     local -a ACME_STANDALONE_CERTS
     local -a LETSENCRYPT_STANDALONE_CERTS
 
@@ -600,27 +601,31 @@ function update_certs {
         if source /app/letsencrypt_user_data; then
             # Backward compatibility: fall back to LETSENCRYPT_STANDALONE_CERTS if ACME_STANDALONE_CERTS is unset
             [[ ${#ACME_STANDALONE_CERTS[@]} -eq 0 ]] && ACME_STANDALONE_CERTS=( "${LETSENCRYPT_STANDALONE_CERTS[@]}" )
-
-            for cid in "${ACME_STANDALONE_CERTS[@]}"; do
-                local hosts_var
-                hosts_var="$(get_hosts_array_var "${cid}")" || continue
-                local -n hosts_array="${hosts_var}"
-                
-                local -n acme_challenge="ACME_${cid}_CHALLENGE"
-                acme_challenge="${acme_challenge:-HTTP-01}"
-                
-                if [[ "${acme_challenge}" == "HTTP-01" ]]; then
-                    for domain in "${hosts_array[@]}"; do
-                        add_standalone_configuration "${domain}"
-                    done
-                fi
-            done
-
-            reload_nginx
             ACME_CONTAINERS+=( "${ACME_STANDALONE_CERTS[@]}" )
         else
             echo "Warning: could not source /app/letsencrypt_user_data, skipping user data"
+            ACME_STANDALONE_CERTS=()
         fi
+    fi
+
+    # Standalone certificates and containers without VIRTUAL_HOST need a standalone challenge configuration.
+    ACME_STANDALONE_CERTS+=( "${ACME_STANDALONE_CONTAINERS[@]}" )
+    if [[ ${#ACME_STANDALONE_CERTS[@]} -gt 0 ]]; then
+        for cid in "${ACME_STANDALONE_CERTS[@]}"; do
+            local hosts_var
+            hosts_var="$(get_hosts_array_var "${cid}")" || continue
+            local -n hosts_array="${hosts_var}"
+
+            local -n acme_challenge="ACME_${cid}_CHALLENGE"
+            acme_challenge="${acme_challenge:-HTTP-01}"
+
+            if [[ "${acme_challenge}" == "HTTP-01" ]]; then
+                for domain in "${hosts_array[@]}"; do
+                    add_standalone_configuration "${domain}"
+                done
+            fi
+        done
+        reload_nginx
     fi
 
     should_reload_nginx='false'

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -33,6 +33,28 @@ ACME_CONTAINERS=(
 {{ end }}
 )
 
+{{/* Containers without VIRTUAL_HOST / VIRTUAL_HOST_MULTIPORTS: certificate obtained through the standalone flow. */}}
+ACME_STANDALONE_CONTAINERS=(
+{{ range $_, $container := $orderedContainers }}
+    {{ $rawHosts := trim (coalesce $container.Env.ACME_HOST $container.Env.LETSENCRYPT_HOST "") }}
+    {{ $hosts := trimSuffix "," $rawHosts }}
+    {{ $virtualHosts := trim (coalesce $container.Env.VIRTUAL_HOST $container.Env.VIRTUAL_HOST_MULTIPORTS "") }}
+    {{ if and $hosts (not $virtualHosts) }}
+        {{ if parseBool (coalesce $container.Env.ACME_SINGLE_DOMAIN_CERTS $container.Env.LETSENCRYPT_SINGLE_DOMAIN_CERTS "false") }}
+            {{ range $host := split $hosts "," }}
+                {{ $host := trim $host }}
+                {{ $host := trimSuffix "." $host }}
+                {{- if $host }}
+                    {{- "\n\t" }}'{{ printf "%.12s" $container.ID }}_{{ sha1 $host }}' # {{ $container.Name }}, created at {{ $container.Created }}
+                {{- end }}
+            {{ end }}
+        {{ else }}
+            {{- "\n\t" }}'{{ printf "%.12s" $container.ID }}' # {{ $container.Name }}, created at {{ $container.Created }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+)
+
 {{ range $_, $container := $orderedContainers }}
     {{/* ACME_HOST is preferred, LETSENCRYPT_HOST kept for backward compatibility. */}}
     {{ $rawHosts := trim (coalesce $container.Env.ACME_HOST $container.Env.LETSENCRYPT_HOST "") }}

--- a/docs/Standalone-certificates.md
+++ b/docs/Standalone-certificates.md
@@ -104,6 +104,21 @@ The container does not actively watch the `/app/letsencrypt_user_data` file for 
 
 Changes will either be picked up every hour when the service loop execute again, or by using `docker exec your-le-container-name-or-id signal_le_service` to manually trigger the service loop execution.
 
+### Standalone certificates from a container's environment variables
+
+If the certificate can be tied to a running container (for instance a mail server that is not proxied by **nginx-proxy**), you don't need the `letsencrypt_user_data` file: a container with an `ACME_HOST` / `LETSENCRYPT_HOST` environment variable but no `VIRTUAL_HOST` / `VIRTUAL_HOST_MULTIPORTS` variable will get its certificate through the standalone flow:
+
+```yaml
+services:
+  smtp:
+    image: mysmtp
+    environment:
+      LETSENCRYPT_HOST: smtp.example.org
+      LETSENCRYPT_RESTART_CONTAINER: "true"
+```
+
+The requirements are the same as for `letsencrypt_user_data` standalone certificates: with the HTTP-01 challenge, the `/etc/nginx/vhost.d` and `/etc/nginx/conf.d` folders must be shared between the **nginx-proxy** and **acme-companion** containers (this does not apply to the DNS-01 challenge). All the per-container [configuration variables](./Container-configuration.md) (`LETSENCRYPT_RESTART_CONTAINER`, `ACME_CHALLENGE`, etc.) are supported.
+
 ### Proxying to something else than a Docker container
 
 Please see the [**nginx-proxy** documentation](https://github.com/nginx-proxy/nginx-proxy#proxy-wide).

--- a/test/config.sh
+++ b/test/config.sh
@@ -11,6 +11,7 @@ globalTests+=(
 	certs_san
 	certs_single_domain
 	certs_standalone
+	standalone_container
 	standalone_ipv6
 	force_renew
 	acme_accounts

--- a/test/tests/standalone_container/run.sh
+++ b/test/tests/standalone_container/run.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+## Test for standalone certificates obtained for containers with an
+## ACME_HOST / LETSENCRYPT_HOST environment variable but no VIRTUAL_HOST.
+
+case ${ACME_CA} in
+  pebble)
+    test_net='acme_net'
+  ;;
+  boulder)
+    test_net='boulder_bluenet'
+  ;;
+  *)
+    echo "$0 ${ACME_CA}: invalid option."
+    exit 1
+esac
+
+if [[ -z ${GITHUB_ACTIONS} ]]; then
+  le_container_name="$(basename "${0%/*}")_$(date "+%Y-%m-%d_%H.%M.%S")"
+else
+  le_container_name="$(basename "${0%/*}")"
+fi
+
+# Create the ${domains} array from comma separated domains in TEST_DOMAINS.
+IFS=',' read -r -a domains <<< "${TEST_DOMAINS}"
+
+# Cleanup function with EXIT trap
+function cleanup {
+  # Remove the test containers silently.
+  docker rm --force "${domains[0]}" "${domains[1]}" &> /dev/null
+  # Cleanup the files created by this run of the test to avoid foiling following test(s).
+  docker exec "${le_container_name}" cleanup_test_artifacts
+  # Stop the LE container
+  docker stop "${le_container_name}" > /dev/null
+}
+trap cleanup EXIT
+
+run_le_container "${1:?}" "${le_container_name}"
+
+# Proxied container: must not go through the standalone flow.
+run_nginx_container --hosts "${domains[0]}"
+
+# Container with only LETSENCRYPT_HOST: certificate obtained through the standalone flow.
+if ! docker run --rm -d \
+    --name "${domains[1]}" \
+    -e "LETSENCRYPT_HOST=${domains[1]}" \
+    --label com.github.nginx-proxy.acme-companion.test-suite \
+    --network "${test_net}" \
+    nginx:alpine > /dev/null;
+then
+  echo "Could not start test container for ${domains[1]}"
+elif [[ "${DRY_RUN:-}" == 1 ]]; then
+  echo "Started test container for ${domains[1]}"
+fi
+
+# Wait for a file at /etc/nginx/conf.d/standalone-cert-${domains[1]}.conf
+wait_for_standalone_conf "${domains[1]}" "${le_container_name}"
+
+# Wait for a symlink at /etc/nginx/certs/${domains[1]}.crt
+if wait_for_symlink "${domains[1]}" "${le_container_name}"; then
+  # then grab the certificate in text form ...
+  created_cert="$(docker exec "${le_container_name}" \
+    openssl x509 -in "/etc/nginx/certs/${domains[1]}/cert.pem" -text -noout)"
+fi
+
+# Check if the domain is on the certificate.
+if ! grep -q "${domains[1]}" <<< "${created_cert}"; then
+  echo "Domain ${domains[1]} did not appear on certificate."
+elif [[ "${DRY_RUN:-}" == 1 ]]; then
+  echo "Domain ${domains[1]} is on certificate."
+fi
+
+# The standalone conf is removed once the certificate is issued; wait for that.
+wait_for_standalone_conf_rm "${domains[1]}" "${le_container_name}"
+
+# The proxied container's certificate is obtained through the regular flow.
+if wait_for_symlink "${domains[0]}" "${le_container_name}"; then
+  created_cert="$(docker exec "${le_container_name}" \
+    openssl x509 -in "/etc/nginx/certs/${domains[0]}/cert.pem" -text -noout)"
+fi
+if ! grep -q "${domains[0]}" <<< "${created_cert}"; then
+  echo "Domain ${domains[0]} did not appear on certificate."
+elif [[ "${DRY_RUN:-}" == 1 ]]; then
+  echo "Domain ${domains[0]} is on certificate."
+fi
+
+# Only the container without VIRTUAL_HOST should be listed in ACME_STANDALONE_CONTAINERS.
+standalone_cid="$(docker inspect --format '{{.Id}}' "${domains[1]}" | cut -c1-12)"
+proxied_cid="$(docker inspect --format '{{.Id}}' "${domains[0]}" | cut -c1-12)"
+standalone_containers="$(docker exec "${le_container_name}" \
+  bash -c 'source /app/letsencrypt_service_data && echo "${ACME_STANDALONE_CONTAINERS[*]}"')"
+if ! grep -q "${standalone_cid}" <<< "${standalone_containers}"; then
+  echo "Container ${domains[1]} (${standalone_cid}) is missing from ACME_STANDALONE_CONTAINERS."
+fi
+if grep -q "${proxied_cid}" <<< "${standalone_containers}"; then
+  echo "Proxied container ${domains[0]} (${proxied_cid}) should not be in ACME_STANDALONE_CONTAINERS."
+fi


### PR DESCRIPTION
Implements the feature proposed in #1128 (standalone certificates from `LETSENCRYPT_HOST` alone, e.g. for an SMTP container that is not proxied), using the approach suggested there: the template now detects containers without `VIRTUAL_HOST` / `VIRTUAL_HOST_MULTIPORTS` instead of routing every certificate through `add_standalone_configuration`, so proxied certificates keep the exact same code path and two-container setups without a shared `/etc/nginx/conf.d` are unaffected.

- `letsencrypt_service_data.tmpl` renders a new `ACME_STANDALONE_CONTAINERS` array listing the identifiers (SAN and single-domain forms) of containers that have an `ACME_HOST` / `LETSENCRYPT_HOST` but no `VIRTUAL_HOST` / `VIRTUAL_HOST_MULTIPORTS`.
- `update_certs` runs those identifiers through the existing standalone challenge configuration pre-pass (shared with `letsencrypt_user_data` certificates); the post-issuance conf removal and cleanup paths are unchanged.
- Since the identifiers are real container IDs, `LETSENCRYPT_RESTART_CONTAINER` works for these certificates, which the `letsencrypt_user_data` route couldn't offer.
- New `standalone_container` integration test: a `LETSENCRYPT_HOST`-only container gets its certificate through the standalone flow, and a proxied container is never classified as standalone.
- Documented in `docs/Standalone-certificates.md`.

Verified locally by rendering the template with docker-gen against dummy containers (SAN, single-domain, `VIRTUAL_HOST` and `VIRTUAL_HOST_MULTIPORTS` variants): only the containers without a virtual host are listed in `ACME_STANDALONE_CONTAINERS`.

Supersedes #1128 if accepted — credit to @pini-gh for the original proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)