### PR TITLE
feat: acme CA bundle

### DIFF
--- a/app/letsencrypt_service.sh
+++ b/app/letsencrypt_service.sh
@@ -189,12 +189,15 @@ function update_cert {
     [[ "${DEBUG}" == 1 ]] && params_base_arr+=(--debug 2)
 
     # Alternative trusted root CA path, used for test with Pebble
-    if [[ -n "${CA_BUNDLE// }" ]]; then
-        if [[ -f "${CA_BUNDLE}" ]]; then
-            params_base_arr+=(--ca-bundle "${CA_BUNDLE}")
-            [[ "${DEBUG}" == 1 ]] && echo "Debug: acme.sh will use ${CA_BUNDLE} as trusted root CA."
+    local -n per_container_ca_bundle="ACME_${cid}_CA_BUNDLE"
+    # keep backward compatibility with CA_BUNDLE
+    local acme_ca_bundle="${per_container_ca_bundle:-${ACME_CA_BUNDLE:-${CA_BUNDLE:-}}}"
+    if [[ -n "${acme_ca_bundle// }" ]]; then
+        if [[ -f "${acme_ca_bundle}" ]]; then
+            params_base_arr+=(--ca-bundle "${acme_ca_bundle}")
+            [[ "${DEBUG}" == 1 ]] && echo "Debug: acme.sh will use ${acme_ca_bundle} as trusted root CA."
         else
-            echo "Warning: the path to the alternate CA bundle (${CA_BUNDLE}) is not valid, using default Alpine trust store."
+            echo "Warning: the path to the alternate CA bundle (${acme_ca_bundle}) is not valid, using default Alpine trust store."
         fi
     fi
 

--- a/app/letsencrypt_service_data.tmpl
+++ b/app/letsencrypt_service_data.tmpl
@@ -43,6 +43,7 @@ ACME_CONTAINERS=(
         {{ $STAGING := trim (coalesce $container.Env.LETSENCRYPT_TEST "") }}
         {{ $EMAIL := trim (coalesce $container.Env.ACME_EMAIL $container.Env.LETSENCRYPT_EMAIL "") }}
         {{ $CA_URI := trim (coalesce $container.Env.ACME_CA_URI "") }}
+        {{ $CA_BUNDLE := trim (coalesce $container.Env.ACME_CA_BUNDLE "") }}
         {{ $ACME_CHALLENGE := trim (coalesce $container.Env.ACME_CHALLENGE "") }}
         {{ $ACME_CERT_PROFILE := trim (coalesce $container.Env.ACME_CERT_PROFILE "") }}
         {{ $ACMESH_DNS_API_CONFIG := fromYaml (coalesce $container.Env.ACMESH_DNS_API_CONFIG "") }}
@@ -69,6 +70,7 @@ ACME_CONTAINERS=(
                 {{- "\n" }}LETSENCRYPT_{{ $cid }}_{{ $hostHash }}_TEST="{{ $STAGING }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_EMAIL="{{ $EMAIL }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_CA_URI="{{ $CA_URI }}"
+                {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_CA_BUNDLE="{{ $CA_BUNDLE }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_CHALLENGE="{{ $ACME_CHALLENGE }}"
                 {{- "\n" }}ACME_{{ $cid }}_{{ $hostHash }}_CERT_PROFILE="{{ $ACME_CERT_PROFILE }}"
                 {{- if $ACMESH_DNS_API_CONFIG }}
@@ -104,6 +106,7 @@ ACME_CONTAINERS=(
             {{- "\n" }}LETSENCRYPT_{{ $cid }}_TEST="{{ $STAGING }}"
             {{- "\n" }}ACME_{{ $cid }}_EMAIL="{{ $EMAIL }}"
             {{- "\n" }}ACME_{{ $cid }}_CA_URI="{{ $CA_URI }}"
+            {{- "\n" }}ACME_{{ $cid }}_CA_BUNDLE="{{ $CA_BUNDLE }}"
             {{- "\n" }}ACME_{{ $cid }}_CHALLENGE="{{ $ACME_CHALLENGE }}"
             {{- "\n" }}ACME_{{ $cid }}_CERT_PROFILE="{{ $ACME_CERT_PROFILE }}"
             {{- if $ACMESH_DNS_API_CONFIG }}

--- a/docs/Container-configuration.md
+++ b/docs/Container-configuration.md
@@ -26,7 +26,7 @@ You can also create test certificates per container (see [Test certificates](./L
 
 * `DHPARAM_SKIP` - Set it to `true` to disable the Diffie-Hellman group creation by the container entirely.
 
-* `CA_BUNDLE` - This is a test only variable [for use with Pebble](https://github.com/letsencrypt/pebble#avoiding-client-https-errors). It changes the trusted root CA used by `acme.sh`, from the default Alpine trust store to the CA bundle file located at the provided path (inside the container). Do **not** use it in production unless you are running your own ACME CA.
+* `ACME_CA_BUNDLE` - This variable changes the trusted root CA used by `acme.sh`, from the default Alpine trust store to the CA bundle file located at the provided path (inside the container). This can be useful if you are running your own ACME CA.
 
 * `CERTS_UPDATE_INTERVAL` - 3600 seconds by default, this defines how often the container will check if the certificates require update.
 

--- a/docs/Environment-variables-reference.md
+++ b/docs/Environment-variables-reference.md
@@ -5,6 +5,7 @@
 | Variable | Default | Legacy Variable | Documentation |
 |---|---|---|---|
 | `ACME_CA_URI` | `https://acme-v02.api.letsencrypt.org/directory` | — | [Container configuration](./Container-configuration.md#optional-container-environment-variables-for-custom-configuration) |
+| `ACME_CA_BUNDLE` | Alpine trust store | — | [Container configuration](./Container-configuration.md#optional-container-environment-variables-for-custom-configuration) |
 | `ACME_CHALLENGE` | `HTTP-01` | — | [Let's Encrypt and ACME › DNS-01 challenge](./Let's-Encrypt-and-ACME.md#dns-01-acme-challenge) |
 | `ACMESH_DNS_API_CONFIG` | — | — | [Let's Encrypt and ACME › DNS-01 challenge](./Let's-Encrypt-and-ACME.md#dns-01-acme-challenge) |
 | `ACME_CERT_PROFILE` | CA default | — | [Let's Encrypt and ACME › Default certificate profile](./Let's-Encrypt-and-ACME.md#default-certificate-profile) |
@@ -14,7 +15,6 @@
 | `ACME_POST_HOOK` | — | — | [Container configuration](./Container-configuration.md#optional-container-environment-variables-for-custom-configuration) · [Hooks](./Hooks.md) |
 | `ACME_PRE_HOOK` | — | — | [Container configuration](./Container-configuration.md#optional-container-environment-variables-for-custom-configuration) · [Hooks](./Hooks.md) |
 | `ACME_RENEW_AFTER` | `60` (days) | `DEFAULT_RENEW` ⚠️ deprecated | [Container configuration](./Container-configuration.md#optional-container-environment-variables-for-custom-configuration) |
-| `CA_BUNDLE` | Alpine trust store | — | [Container configuration](./Container-configuration.md#optional-container-environment-variables-for-custom-configuration) |
 | `CERTS_UPDATE_INTERVAL` | `3600` (seconds) | — | [Container configuration](./Container-configuration.md#optional-container-environment-variables-for-custom-configuration) |
 | `CREATE_DEFAULT_CERTIFICATE` | `false` | — | [Let's Encrypt and ACME › Self signed default certificate](./Let's-Encrypt-and-ACME.md#self-signed-default-certificate) |
 | `DEBUG` | `0` | — | [Container configuration](./Container-configuration.md#optional-container-environment-variables-for-custom-configuration) |
@@ -46,6 +46,7 @@
 | `ACME_HOST` | — | `LETSENCRYPT_HOST` | [Basic usage](./Basic-usage.md) · [Let's Encrypt and ACME](./Let's-Encrypt-and-ACME.md) |
 | `ACME_EMAIL` | `DEFAULT_EMAIL` or none | `LETSENCRYPT_EMAIL` | [Let's Encrypt and ACME › Contact address](./Let's-Encrypt-and-ACME.md#contact-address) |
 | `ACME_CA_URI` | acme-companion's `ACME_CA_URI` | — | [Let's Encrypt and ACME › ACME CA URI](./Let's-Encrypt-and-ACME.md#acme-ca-uri) |
+| `ACME_CA_BUNDLE` | acme-companion's `ACME_CA_BUNDLE` | — | [Let's Encrypt and ACME › Alternate trusted root CA](./Let's-Encrypt-and-ACME.md#alternate-trusted-root-ca) |
 | `ACME_CHALLENGE` | acme-companion's `ACME_CHALLENGE` | — | [Let's Encrypt and ACME › DNS-01 challenge](./Let's-Encrypt-and-ACME.md#dns-01-acme-challenge) |
 | `ACMESH_DNS_API_CONFIG` | acme-companion's `ACMESH_DNS_API_CONFIG` | — | [Let's Encrypt and ACME › DNS-01 challenge](./Let's-Encrypt-and-ACME.md#dns-01-acme-challenge) |
 | `ACME_CERT_PROFILE` | acme-companion's `ACME_CERT_PROFILE` or CA default | — | [Let's Encrypt and ACME › Certificate profile](./Let's-Encrypt-and-ACME.md#certificate-profile) |

--- a/docs/Let's-Encrypt-and-ACME.md
+++ b/docs/Let's-Encrypt-and-ACME.md
@@ -122,6 +122,11 @@ If you want to do this globally for all containers, set `ACME_CA_URI` on the **a
 
 The `ACME_CA_URI` environment variable is used to set the ACME API endpoint from which the container's certificate(s) will be requested (defaults to ``https://acme-v02.api.letsencrypt.org/directory``).
 
+#### Alternate trusted root CA
+
+The `ACME_CA_BUNDLE` environment variable is used to set the path to an alternate trusted root CA bundle file that must be mounted or copied inside the **acme-companion** container (defaults to the Alpine trust store). This can be useful if you are running your own ACME CA.
+
+
 #### Preferred chain
 
 If the ACME CA provides multiple cert chain, you can use the `ACME_PREFERRED_CHAIN` environment variable to select one. See [`acme.sh --preferred-chain` documentation](https://github.com/acmesh-official/acme.sh/wiki/Preferred-Chain) for more info.

--- a/test/tests/test-functions.sh
+++ b/test/tests/test-functions.sh
@@ -48,7 +48,7 @@ function run_le_container {
     cli_args_arr+=(--network boulder_bluenet)
   elif [[ "${ACME_CA}" == 'pebble' ]]; then
     cli_args_arr+=(--env "ACME_CA_URI=https://pebble:14000/dir")
-    cli_args_arr+=(--env "CA_BUNDLE=/pebble.minica.pem")
+    cli_args_arr+=(--env "ACME_CA_BUNDLE=/pebble.minica.pem")
     cli_args_arr+=(--network acme_net)
     cli_args_arr+=(--volume "${GITHUB_WORKSPACE}/pebble.minica.pem:/pebble.minica.pem")
   else


### PR DESCRIPTION
This PR make the ability to specify an alternate CA bundle official (rather than a test only, "do not use in production", semi advertised feature) and the possibility to configure it by proxied container.

Fixes #1295 