### PR TITLE
test: disable Pebble's random nonce rejection

### DIFF
--- a/test/setup/pebble/compose.yaml
+++ b/test/setup/pebble/compose.yaml
@@ -6,6 +6,7 @@ services:
       - "./${PEBBLE_CONFIG}:/test/config/pebble-config.json"
     environment:
       - PEBBLE_VA_NOSLEEP=1
+      - PEBBLE_WFE_NONCEREJECT=0
     command: -config /test/config/pebble-config.json -dnsserver 10.30.50.3:8053
     ports:
       - 14000:14000 # HTTPS ACME API


### PR DESCRIPTION
By default Pebble rejects 5% of all valid nonces to exercise ACME clients' retry logic. Over the dozens of ACME requests a single issuance makes, those random `badNonce` rejections occasionally cluster and stretch issuance past the tests' fixed wait windows, which is the main source of flaky failures like [this `acme_accounts` timeout](https://github.com/nginx-proxy/acme-companion/actions/runs/29619472227/job/88011516790) or the `certs_san` failure that motivated #1290 (both logs are full of `urn:ietf:params:acme:error:badNonce`).

Exercising acme.sh's nonce retry path is an acme.sh concern rather than something these integration tests need to fuzz on every run, and the test setup already disables Pebble's other deliberate randomness with `PEBBLE_VA_NOSLEEP=1`, so this sets `PEBBLE_WFE_NONCEREJECT=0` alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)