### PR TITLE
ci: check every shell script in the ShellCheck workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,11 @@ on:
       - main
     paths:
       - "**/*.sh"
+      - ".github/workflows/lint.yml"
   pull_request:
     paths:
       - "**/*.sh"
+      - ".github/workflows/lint.yml"
 
 jobs:
   shellcheck:
@@ -24,4 +26,6 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run ShellCheck
-        run: shellcheck **/*.sh
+        run: |
+          shopt -s globstar
+          shellcheck **/*.sh


### PR DESCRIPTION
`run:` steps use bash with `globstar` disabled (the bash default), so `**` collapses to `*` and `shellcheck **/*.sh` only matches paths exactly one directory deep. That is 11 of the 43 shell scripts in the repository: `app/*.sh`, `test/config.sh` and `test/run.sh`.

Everything else is silently skipped, including `install_acme.sh` (at the repository root, so zero directories deep), `test/tests/*/run.sh`, `test/tests/test-functions.sh`, `test/setup/**` and `test/github_actions/containers-logs.sh`. In #1273 an SC2250 violation in `test/tests/container_health/run.sh` went unreported for that reason while the violations in `app/` were caught. The workflow's `paths` filter uses GitHub's own glob syntax, where `**` does recurse, so the workflow triggers on changes it then doesn't check.

Enabling `globstar` makes the existing pattern match all 43 files, root-level scripts included. Every one of them currently passes, so this doesn't require any other change.

The workflow file is also added to the `paths` filter: without it a change to the workflow doesn't run it, so the first revision of this PR only ran the test suite and couldn't show the fix working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)